### PR TITLE
fix store operator starting with v

### DIFF
--- a/auto-generated/rif.def
+++ b/auto-generated/rif.def
@@ -1,47 +1,47 @@
-CUSTOM_OP_TYPE(Vle16X16VFloat16SF16, le16_x, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 1, ScalarFloat16)
-CUSTOM_OP_TYPE(Vle32X32VFloat32SF32, le32_x, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 1, ScalarFloat32)
-CUSTOM_OP_TYPE(Vle64X64VFloat64SF64, le64_x, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 1, ScalarFloat64)
-CUSTOM_OP_TYPE(Vle8X8VInt8SI, le8_x, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 1, ScalarInt8)
-CUSTOM_OP_TYPE(Vle16X16VInt16SI, le16_x, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 1, ScalarInt16)
-CUSTOM_OP_TYPE(Vle32X32VInt32SI, le32_x, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 1, ScalarInt32)
-CUSTOM_OP_TYPE(Vle64X64VInt64SI, le64_x, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 1, ScalarInt64)
-CUSTOM_OP_TYPE(Vle8X8VUInt8SU, le8_x, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 1, ScalarUInt8)
-CUSTOM_OP_TYPE(Vle16X16VUInt16SU, le16_x, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 1, ScalarUInt16)
-CUSTOM_OP_TYPE(Vle32X32VUInt32SU, le32_x, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 1, ScalarUInt32)
-CUSTOM_OP_TYPE(Vle64X64VUInt64SU, le64_x, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 1, ScalarUInt64)
-CUSTOM_OP_TYPE(Vle16X16VFloat16VBSF16_m, le16_x, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 2, OneDBool, ScalarFloat16)
-CUSTOM_OP_TYPE(Vle32X32VFloat32VBSF32_m, le32_x, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 2, OneDBool, ScalarFloat32)
-CUSTOM_OP_TYPE(Vle64X64VFloat64VBSF64_m, le64_x, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 2, OneDBool, ScalarFloat64)
-CUSTOM_OP_TYPE(Vle8X8VInt8VBSI_m, le8_x, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 2, OneDBool, ScalarInt8)
-CUSTOM_OP_TYPE(Vle16X16VInt16VBSI_m, le16_x, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 2, OneDBool, ScalarInt16)
-CUSTOM_OP_TYPE(Vle32X32VInt32VBSI_m, le32_x, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 2, OneDBool, ScalarInt32)
-CUSTOM_OP_TYPE(Vle64X64VInt64VBSI_m, le64_x, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 2, OneDBool, ScalarInt64)
-CUSTOM_OP_TYPE(Vle8X8VUInt8VBSU_m, le8_x, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 2, OneDBool, ScalarUInt8)
-CUSTOM_OP_TYPE(Vle16X16VUInt16VBSU_m, le16_x, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 2, OneDBool, ScalarUInt16)
-CUSTOM_OP_TYPE(Vle32X32VUInt32VBSU_m, le32_x, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 2, OneDBool, ScalarUInt32)
-CUSTOM_OP_TYPE(Vle64X64VUInt64VBSU_m, le64_x, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 2, OneDBool, ScalarUInt64)
-CUSTOM_OP_TYPE(Vse16X16VoidSF16VF, vse16_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 2, ScalarFloat16, OneDFloat16)
-CUSTOM_OP_TYPE(Vse32X32VoidSF32VF, vse32_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 2, ScalarFloat32, OneDFloat32)
-CUSTOM_OP_TYPE(Vse64X64VoidSF64VF, vse64_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 2, ScalarFloat64, OneDFloat64)
-CUSTOM_OP_TYPE(Vse8X8VoidSIVI, vse8_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 2, ScalarInt8, OneDInt8)
-CUSTOM_OP_TYPE(Vse16X16VoidSIVI, vse16_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 2, ScalarInt16, OneDInt16)
-CUSTOM_OP_TYPE(Vse32X32VoidSIVI, vse32_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 2, ScalarInt32, OneDInt32)
-CUSTOM_OP_TYPE(Vse64X64VoidSIVI, vse64_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 2, ScalarInt64, OneDInt64)
-CUSTOM_OP_TYPE(Vse8X8VoidSUVU, vse8_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 2, ScalarUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(Vse16X16VoidSUVU, vse16_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 2, ScalarUInt16, OneDUInt16)
-CUSTOM_OP_TYPE(Vse32X32VoidSUVU, vse32_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 2, ScalarUInt32, OneDUInt32)
-CUSTOM_OP_TYPE(Vse64X64VoidSUVU, vse64_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 2, ScalarUInt64, OneDUInt64)
-CUSTOM_OP_TYPE(Vse16X16VoidVBSF16VF_m, vse16_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, OneDFloat16)
-CUSTOM_OP_TYPE(Vse32X32VoidVBSF32VF_m, vse32_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, OneDFloat32)
-CUSTOM_OP_TYPE(Vse64X64VoidVBSF64VF_m, vse64_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, OneDFloat64)
-CUSTOM_OP_TYPE(Vse8X8VoidVBSIVI_m, vse8_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, OneDBool, ScalarInt8, OneDInt8)
-CUSTOM_OP_TYPE(Vse16X16VoidVBSIVI_m, vse16_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, OneDBool, ScalarInt16, OneDInt16)
-CUSTOM_OP_TYPE(Vse32X32VoidVBSIVI_m, vse32_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, OneDBool, ScalarInt32, OneDInt32)
-CUSTOM_OP_TYPE(Vse64X64VoidVBSIVI_m, vse64_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, OneDBool, ScalarInt64, OneDInt64)
-CUSTOM_OP_TYPE(Vse8X8VoidVBSUVU_m, vse8_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(Vse16X16VoidVBSUVU_m, vse16_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, OneDUInt16)
-CUSTOM_OP_TYPE(Vse32X32VoidVBSUVU_m, vse32_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, OneDUInt32)
-CUSTOM_OP_TYPE(Vse64X64VoidVBSUVU_m, vse64_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, OneDUInt64)
+CUSTOM_OP_TYPE(Le16X16VFloat16SF16, le16_x, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 1, ScalarFloat16)
+CUSTOM_OP_TYPE(Le32X32VFloat32SF32, le32_x, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 1, ScalarFloat32)
+CUSTOM_OP_TYPE(Le64X64VFloat64SF64, le64_x, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 1, ScalarFloat64)
+CUSTOM_OP_TYPE(Le8X8VInt8SI, le8_x, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 1, ScalarInt8)
+CUSTOM_OP_TYPE(Le16X16VInt16SI, le16_x, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 1, ScalarInt16)
+CUSTOM_OP_TYPE(Le32X32VInt32SI, le32_x, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 1, ScalarInt32)
+CUSTOM_OP_TYPE(Le64X64VInt64SI, le64_x, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 1, ScalarInt64)
+CUSTOM_OP_TYPE(Le8X8VUInt8SU, le8_x, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 1, ScalarUInt8)
+CUSTOM_OP_TYPE(Le16X16VUInt16SU, le16_x, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 1, ScalarUInt16)
+CUSTOM_OP_TYPE(Le32X32VUInt32SU, le32_x, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 1, ScalarUInt32)
+CUSTOM_OP_TYPE(Le64X64VUInt64SU, le64_x, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 1, ScalarUInt64)
+CUSTOM_OP_TYPE(Le16X16VFloat16VBSF16_m, le16_x, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 2, OneDBool, ScalarFloat16)
+CUSTOM_OP_TYPE(Le32X32VFloat32VBSF32_m, le32_x, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 2, OneDBool, ScalarFloat32)
+CUSTOM_OP_TYPE(Le64X64VFloat64VBSF64_m, le64_x, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 2, OneDBool, ScalarFloat64)
+CUSTOM_OP_TYPE(Le8X8VInt8VBSI_m, le8_x, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 2, OneDBool, ScalarInt8)
+CUSTOM_OP_TYPE(Le16X16VInt16VBSI_m, le16_x, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 2, OneDBool, ScalarInt16)
+CUSTOM_OP_TYPE(Le32X32VInt32VBSI_m, le32_x, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 2, OneDBool, ScalarInt32)
+CUSTOM_OP_TYPE(Le64X64VInt64VBSI_m, le64_x, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 2, OneDBool, ScalarInt64)
+CUSTOM_OP_TYPE(Le8X8VUInt8VBSU_m, le8_x, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 2, OneDBool, ScalarUInt8)
+CUSTOM_OP_TYPE(Le16X16VUInt16VBSU_m, le16_x, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 2, OneDBool, ScalarUInt16)
+CUSTOM_OP_TYPE(Le32X32VUInt32VBSU_m, le32_x, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 2, OneDBool, ScalarUInt32)
+CUSTOM_OP_TYPE(Le64X64VUInt64VBSU_m, le64_x, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 2, OneDBool, ScalarUInt64)
+CUSTOM_OP_TYPE(Se16X16VoidSF16VF, se16_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 2, ScalarFloat16, OneDFloat16)
+CUSTOM_OP_TYPE(Se32X32VoidSF32VF, se32_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 2, ScalarFloat32, OneDFloat32)
+CUSTOM_OP_TYPE(Se64X64VoidSF64VF, se64_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 2, ScalarFloat64, OneDFloat64)
+CUSTOM_OP_TYPE(Se8X8VoidSIVI, se8_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 2, ScalarInt8, OneDInt8)
+CUSTOM_OP_TYPE(Se16X16VoidSIVI, se16_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 2, ScalarInt16, OneDInt16)
+CUSTOM_OP_TYPE(Se32X32VoidSIVI, se32_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 2, ScalarInt32, OneDInt32)
+CUSTOM_OP_TYPE(Se64X64VoidSIVI, se64_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 2, ScalarInt64, OneDInt64)
+CUSTOM_OP_TYPE(Se8X8VoidSUVU, se8_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 2, ScalarUInt8, OneDUInt8)
+CUSTOM_OP_TYPE(Se16X16VoidSUVU, se16_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 2, ScalarUInt16, OneDUInt16)
+CUSTOM_OP_TYPE(Se32X32VoidSUVU, se32_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 2, ScalarUInt32, OneDUInt32)
+CUSTOM_OP_TYPE(Se64X64VoidSUVU, se64_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 2, ScalarUInt64, OneDUInt64)
+CUSTOM_OP_TYPE(Se16X16VoidVBSF16VF_m, se16_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, OneDFloat16)
+CUSTOM_OP_TYPE(Se32X32VoidVBSF32VF_m, se32_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, OneDFloat32)
+CUSTOM_OP_TYPE(Se64X64VoidVBSF64VF_m, se64_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, OneDFloat64)
+CUSTOM_OP_TYPE(Se8X8VoidVBSIVI_m, se8_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, OneDBool, ScalarInt8, OneDInt8)
+CUSTOM_OP_TYPE(Se16X16VoidVBSIVI_m, se16_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, OneDBool, ScalarInt16, OneDInt16)
+CUSTOM_OP_TYPE(Se32X32VoidVBSIVI_m, se32_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, OneDBool, ScalarInt32, OneDInt32)
+CUSTOM_OP_TYPE(Se64X64VoidVBSIVI_m, se64_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, OneDBool, ScalarInt64, OneDInt64)
+CUSTOM_OP_TYPE(Se8X8VoidVBSUVU_m, se8_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, OneDUInt8)
+CUSTOM_OP_TYPE(Se16X16VoidVBSUVU_m, se16_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, OneDUInt16)
+CUSTOM_OP_TYPE(Se32X32VoidVBSUVU_m, se32_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, OneDUInt32)
+CUSTOM_OP_TYPE(Se64X64VoidVBSUVU_m, se64_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, OneDUInt64)
 CUSTOM_OP_TYPE(Lm0VBoolSU, lm_, 0, BOOL, HaveVLParameter | NonmaskedOperation, OneDBool, 1, ScalarUInt8)
 CUSTOM_OP_TYPE(Lm0VBoolSU, lm_, 0, BOOL, HaveVLParameter | NonmaskedOperation, OneDBool, 1, ScalarUInt8)
 CUSTOM_OP_TYPE(Lm0VBoolSU, lm_, 0, BOOL, HaveVLParameter | NonmaskedOperation, OneDBool, 1, ScalarUInt8)
@@ -56,424 +56,424 @@ CUSTOM_OP_TYPE(Sm0VoidSUVB, sm_, 0, VOID, HaveVLParameter | NonmaskedOperation |
 CUSTOM_OP_TYPE(Sm0VoidSUVB, sm_, 0, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 2, ScalarUInt8, OneDBool)
 CUSTOM_OP_TYPE(Sm0VoidSUVB, sm_, 0, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 2, ScalarUInt8, OneDBool)
 CUSTOM_OP_TYPE(Sm0VoidSUVB, sm_, 0, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 2, ScalarUInt8, OneDBool)
-CUSTOM_OP_TYPE(Vlse16XX16VFloat16SF16SI, lse16_xx, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse32XX32VFloat32SF32SI, lse32_xx, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse64XX64VFloat64SF64SI, lse64_xx, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse8XX8VInt8SISI, lse8_xx, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse16XX16VInt16SISI, lse16_xx, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse32XX32VInt32SISI, lse32_xx, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse64XX64VInt64SISI, lse64_xx, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse8XX8VUInt8SUSI, lse8_xx, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse16XX16VUInt16SUSI, lse16_xx, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse32XX32VUInt32SUSI, lse32_xx, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse64XX64VUInt64SUSI, lse64_xx, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse16XX16VFloat16VBSF16SI_m, lse16_xx, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse32XX32VFloat32VBSF32SI_m, lse32_xx, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse64XX64VFloat64VBSF64SI_m, lse64_xx, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse8XX8VInt8VBSISI_m, lse8_xx, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse16XX16VInt16VBSISI_m, lse16_xx, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse32XX32VInt32VBSISI_m, lse32_xx, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse64XX64VInt64VBSISI_m, lse64_xx, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse8XX8VUInt8VBSUSI_m, lse8_xx, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse16XX16VUInt16VBSUSI_m, lse16_xx, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse32XX32VUInt32VBSUSI_m, lse32_xx, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vlse64XX64VUInt64VBSUSI_m, lse64_xx, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, ScalarIntXLen)
-CUSTOM_OP_TYPE(Vsse16XX16VoidSF16SIVF, vsse16_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, ScalarFloat16, ScalarIntXLen, OneDFloat16)
-CUSTOM_OP_TYPE(Vsse32XX32VoidSF32SIVF, vsse32_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, ScalarFloat32, ScalarIntXLen, OneDFloat32)
-CUSTOM_OP_TYPE(Vsse64XX64VoidSF64SIVF, vsse64_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, ScalarFloat64, ScalarIntXLen, OneDFloat64)
-CUSTOM_OP_TYPE(Vsse8XX8VoidSISIVI, vsse8_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, ScalarInt8, ScalarIntXLen, OneDInt8)
-CUSTOM_OP_TYPE(Vsse16XX16VoidSISIVI, vsse16_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, ScalarInt16, ScalarIntXLen, OneDInt16)
-CUSTOM_OP_TYPE(Vsse32XX32VoidSISIVI, vsse32_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, ScalarInt32, ScalarIntXLen, OneDInt32)
-CUSTOM_OP_TYPE(Vsse64XX64VoidSISIVI, vsse64_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, ScalarInt64, ScalarIntXLen, OneDInt64)
-CUSTOM_OP_TYPE(Vsse8XX8VoidSUSIVU, vsse8_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, ScalarUInt8, ScalarIntXLen, OneDUInt8)
-CUSTOM_OP_TYPE(Vsse16XX16VoidSUSIVU, vsse16_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, ScalarUInt16, ScalarIntXLen, OneDUInt16)
-CUSTOM_OP_TYPE(Vsse32XX32VoidSUSIVU, vsse32_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, ScalarUInt32, ScalarIntXLen, OneDUInt32)
-CUSTOM_OP_TYPE(Vsse64XX64VoidSUSIVU, vsse64_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, ScalarUInt64, ScalarIntXLen, OneDUInt64)
-CUSTOM_OP_TYPE(Vsse16XX16VoidVBSF16SIVF_m, vsse16_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 4, OneDBool, ScalarFloat16, ScalarIntXLen, OneDFloat16)
-CUSTOM_OP_TYPE(Vsse32XX32VoidVBSF32SIVF_m, vsse32_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 4, OneDBool, ScalarFloat32, ScalarIntXLen, OneDFloat32)
-CUSTOM_OP_TYPE(Vsse64XX64VoidVBSF64SIVF_m, vsse64_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 4, OneDBool, ScalarFloat64, ScalarIntXLen, OneDFloat64)
-CUSTOM_OP_TYPE(Vsse8XX8VoidVBSISIVI_m, vsse8_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 4, OneDBool, ScalarInt8, ScalarIntXLen, OneDInt8)
-CUSTOM_OP_TYPE(Vsse16XX16VoidVBSISIVI_m, vsse16_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 4, OneDBool, ScalarInt16, ScalarIntXLen, OneDInt16)
-CUSTOM_OP_TYPE(Vsse32XX32VoidVBSISIVI_m, vsse32_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 4, OneDBool, ScalarInt32, ScalarIntXLen, OneDInt32)
-CUSTOM_OP_TYPE(Vsse64XX64VoidVBSISIVI_m, vsse64_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 4, OneDBool, ScalarInt64, ScalarIntXLen, OneDInt64)
-CUSTOM_OP_TYPE(Vsse8XX8VoidVBSUSIVU_m, vsse8_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 4, OneDBool, ScalarUInt8, ScalarIntXLen, OneDUInt8)
-CUSTOM_OP_TYPE(Vsse16XX16VoidVBSUSIVU_m, vsse16_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 4, OneDBool, ScalarUInt16, ScalarIntXLen, OneDUInt16)
-CUSTOM_OP_TYPE(Vsse32XX32VoidVBSUSIVU_m, vsse32_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 4, OneDBool, ScalarUInt32, ScalarIntXLen, OneDUInt32)
-CUSTOM_OP_TYPE(Vsse64XX64VoidVBSUSIVU_m, vsse64_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 4, OneDBool, ScalarUInt64, ScalarIntXLen, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V16VFloat16SF16VU, loxei8_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V16VFloat16SF16VU, loxei16_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V16VFloat16SF16VU, loxei32_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V16VFloat16SF16VU, loxei64_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V32VFloat32SF32VU, loxei8_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V32VFloat32SF32VU, loxei16_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V32VFloat32SF32VU, loxei32_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V32VFloat32SF32VU, loxei64_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V64VFloat64SF64VU, loxei8_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V64VFloat64SF64VU, loxei16_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V64VFloat64SF64VU, loxei32_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V64VFloat64SF64VU, loxei64_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V16VFloat16SF16VU, luxei8_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V16VFloat16SF16VU, luxei16_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V16VFloat16SF16VU, luxei32_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V16VFloat16SF16VU, luxei64_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V32VFloat32SF32VU, luxei8_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V32VFloat32SF32VU, luxei16_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V32VFloat32SF32VU, luxei32_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V32VFloat32SF32VU, luxei64_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V64VFloat64SF64VU, luxei8_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V64VFloat64SF64VU, luxei16_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V64VFloat64SF64VU, luxei32_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V64VFloat64SF64VU, luxei64_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V8VInt8SIVU, loxei8_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V8VInt8SIVU, loxei16_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V8VInt8SIVU, loxei32_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V8VInt8SIVU, loxei64_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V16VInt16SIVU, loxei8_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V16VInt16SIVU, loxei16_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V16VInt16SIVU, loxei32_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V16VInt16SIVU, loxei64_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V32VInt32SIVU, loxei8_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V32VInt32SIVU, loxei16_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V32VInt32SIVU, loxei32_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V32VInt32SIVU, loxei64_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V64VInt64SIVU, loxei8_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V64VInt64SIVU, loxei16_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V64VInt64SIVU, loxei32_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V64VInt64SIVU, loxei64_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V8VInt8SIVU, luxei8_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V8VInt8SIVU, luxei16_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V8VInt8SIVU, luxei32_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V8VInt8SIVU, luxei64_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V16VInt16SIVU, luxei8_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V16VInt16SIVU, luxei16_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V16VInt16SIVU, luxei32_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V16VInt16SIVU, luxei64_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V32VInt32SIVU, luxei8_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V32VInt32SIVU, luxei16_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V32VInt32SIVU, luxei32_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V32VInt32SIVU, luxei64_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V64VInt64SIVU, luxei8_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V64VInt64SIVU, luxei16_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V64VInt64SIVU, luxei32_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V64VInt64SIVU, luxei64_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V8VUInt8SUVU, loxei8_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V8VUInt8SUVU, loxei16_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V8VUInt8SUVU, loxei32_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V8VUInt8SUVU, loxei64_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V16VUInt16SUVU, loxei8_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V16VUInt16SUVU, loxei16_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V16VUInt16SUVU, loxei32_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V16VUInt16SUVU, loxei64_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V32VUInt32SUVU, loxei8_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V32VUInt32SUVU, loxei16_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V32VUInt32SUVU, loxei32_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V32VUInt32SUVU, loxei64_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V64VUInt64SUVU, loxei8_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V64VUInt64SUVU, loxei16_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V64VUInt64SUVU, loxei32_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V64VUInt64SUVU, loxei64_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V8VUInt8SUVU, luxei8_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V8VUInt8SUVU, luxei16_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V8VUInt8SUVU, luxei32_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V8VUInt8SUVU, luxei64_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V16VUInt16SUVU, luxei8_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V16VUInt16SUVU, luxei16_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V16VUInt16SUVU, luxei32_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V16VUInt16SUVU, luxei64_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V32VUInt32SUVU, luxei8_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V32VUInt32SUVU, luxei16_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V32VUInt32SUVU, luxei32_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V32VUInt32SUVU, luxei64_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V64VUInt64SUVU, luxei8_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V64VUInt64SUVU, luxei16_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V64VUInt64SUVU, luxei32_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V64VUInt64SUVU, luxei64_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V16VFloat16VBSF16VU_m, loxei8_v, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V16VFloat16VBSF16VU_m, loxei16_v, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V16VFloat16VBSF16VU_m, loxei32_v, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V16VFloat16VBSF16VU_m, loxei64_v, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V32VFloat32VBSF32VU_m, loxei8_v, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V32VFloat32VBSF32VU_m, loxei16_v, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V32VFloat32VBSF32VU_m, loxei32_v, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V32VFloat32VBSF32VU_m, loxei64_v, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V64VFloat64VBSF64VU_m, loxei8_v, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V64VFloat64VBSF64VU_m, loxei16_v, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V64VFloat64VBSF64VU_m, loxei32_v, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V64VFloat64VBSF64VU_m, loxei64_v, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V16VFloat16VBSF16VU_m, luxei8_v, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V16VFloat16VBSF16VU_m, luxei16_v, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V16VFloat16VBSF16VU_m, luxei32_v, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V16VFloat16VBSF16VU_m, luxei64_v, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V32VFloat32VBSF32VU_m, luxei8_v, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V32VFloat32VBSF32VU_m, luxei16_v, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V32VFloat32VBSF32VU_m, luxei32_v, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V32VFloat32VBSF32VU_m, luxei64_v, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V64VFloat64VBSF64VU_m, luxei8_v, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V64VFloat64VBSF64VU_m, luxei16_v, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V64VFloat64VBSF64VU_m, luxei32_v, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V64VFloat64VBSF64VU_m, luxei64_v, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V8VInt8VBSIVU_m, loxei8_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V8VInt8VBSIVU_m, loxei16_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V8VInt8VBSIVU_m, loxei32_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V8VInt8VBSIVU_m, loxei64_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V16VInt16VBSIVU_m, loxei8_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V16VInt16VBSIVU_m, loxei16_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V16VInt16VBSIVU_m, loxei32_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V16VInt16VBSIVU_m, loxei64_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V32VInt32VBSIVU_m, loxei8_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V32VInt32VBSIVU_m, loxei16_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V32VInt32VBSIVU_m, loxei32_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V32VInt32VBSIVU_m, loxei64_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V64VInt64VBSIVU_m, loxei8_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V64VInt64VBSIVU_m, loxei16_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V64VInt64VBSIVU_m, loxei32_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V64VInt64VBSIVU_m, loxei64_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V8VInt8VBSIVU_m, luxei8_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V8VInt8VBSIVU_m, luxei16_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V8VInt8VBSIVU_m, luxei32_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V8VInt8VBSIVU_m, luxei64_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V16VInt16VBSIVU_m, luxei8_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V16VInt16VBSIVU_m, luxei16_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V16VInt16VBSIVU_m, luxei32_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V16VInt16VBSIVU_m, luxei64_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V32VInt32VBSIVU_m, luxei8_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V32VInt32VBSIVU_m, luxei16_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V32VInt32VBSIVU_m, luxei32_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V32VInt32VBSIVU_m, luxei64_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V64VInt64VBSIVU_m, luxei8_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V64VInt64VBSIVU_m, luxei16_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V64VInt64VBSIVU_m, luxei32_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V64VInt64VBSIVU_m, luxei64_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V8VUInt8VBSUVU_m, loxei8_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V8VUInt8VBSUVU_m, loxei16_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V8VUInt8VBSUVU_m, loxei32_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V8VUInt8VBSUVU_m, loxei64_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V16VUInt16VBSUVU_m, loxei8_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V16VUInt16VBSUVU_m, loxei16_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V16VUInt16VBSUVU_m, loxei32_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V16VUInt16VBSUVU_m, loxei64_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V32VUInt32VBSUVU_m, loxei8_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V32VUInt32VBSUVU_m, loxei16_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V32VUInt32VBSUVU_m, loxei32_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V32VUInt32VBSUVU_m, loxei64_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, OneDUInt64)
-CUSTOM_OP_TYPE(Vloxei8V64VUInt64VBSUVU_m, loxei8_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, OneDUInt8)
-CUSTOM_OP_TYPE(Vloxei16V64VUInt64VBSUVU_m, loxei16_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, OneDUInt16)
-CUSTOM_OP_TYPE(Vloxei32V64VUInt64VBSUVU_m, loxei32_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, OneDUInt32)
-CUSTOM_OP_TYPE(Vloxei64V64VUInt64VBSUVU_m, loxei64_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V8VUInt8VBSUVU_m, luxei8_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V8VUInt8VBSUVU_m, luxei16_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V8VUInt8VBSUVU_m, luxei32_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V8VUInt8VBSUVU_m, luxei64_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V16VUInt16VBSUVU_m, luxei8_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V16VUInt16VBSUVU_m, luxei16_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V16VUInt16VBSUVU_m, luxei32_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V16VUInt16VBSUVU_m, luxei64_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V32VUInt32VBSUVU_m, luxei8_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V32VUInt32VBSUVU_m, luxei16_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V32VUInt32VBSUVU_m, luxei32_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V32VUInt32VBSUVU_m, luxei64_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, OneDUInt64)
-CUSTOM_OP_TYPE(Vluxei8V64VUInt64VBSUVU_m, luxei8_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, OneDUInt8)
-CUSTOM_OP_TYPE(Vluxei16V64VUInt64VBSUVU_m, luxei16_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, OneDUInt16)
-CUSTOM_OP_TYPE(Vluxei32V64VUInt64VBSUVU_m, luxei32_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, OneDUInt32)
-CUSTOM_OP_TYPE(Vluxei64V64VUInt64VBSUVU_m, luxei64_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, OneDUInt64)
-CUSTOM_OP_TYPE(Vsoxei8V16VoidSF16VUVF, vsoxei8_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, ScalarFloat16, OneDUInt8, OneDFloat16)
-CUSTOM_OP_TYPE(Vsoxei16V16VoidSF16VUVF, vsoxei16_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, ScalarFloat16, OneDUInt16, OneDFloat16)
-CUSTOM_OP_TYPE(Vsoxei32V16VoidSF16VUVF, vsoxei32_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, ScalarFloat16, OneDUInt32, OneDFloat16)
-CUSTOM_OP_TYPE(Vsoxei64V16VoidSF16VUVF, vsoxei64_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, ScalarFloat16, OneDUInt64, OneDFloat16)
-CUSTOM_OP_TYPE(Vsoxei8V32VoidSF32VUVF, vsoxei8_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, ScalarFloat32, OneDUInt8, OneDFloat32)
-CUSTOM_OP_TYPE(Vsoxei16V32VoidSF32VUVF, vsoxei16_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, ScalarFloat32, OneDUInt16, OneDFloat32)
-CUSTOM_OP_TYPE(Vsoxei32V32VoidSF32VUVF, vsoxei32_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, ScalarFloat32, OneDUInt32, OneDFloat32)
-CUSTOM_OP_TYPE(Vsoxei64V32VoidSF32VUVF, vsoxei64_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, ScalarFloat32, OneDUInt64, OneDFloat32)
-CUSTOM_OP_TYPE(Vsoxei8V64VoidSF64VUVF, vsoxei8_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, ScalarFloat64, OneDUInt8, OneDFloat64)
-CUSTOM_OP_TYPE(Vsoxei16V64VoidSF64VUVF, vsoxei16_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, ScalarFloat64, OneDUInt16, OneDFloat64)
-CUSTOM_OP_TYPE(Vsoxei32V64VoidSF64VUVF, vsoxei32_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, ScalarFloat64, OneDUInt32, OneDFloat64)
-CUSTOM_OP_TYPE(Vsoxei64V64VoidSF64VUVF, vsoxei64_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, ScalarFloat64, OneDUInt64, OneDFloat64)
-CUSTOM_OP_TYPE(Vsuxei8V16VoidSF16VUVF, vsuxei8_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, ScalarFloat16, OneDUInt8, OneDFloat16)
-CUSTOM_OP_TYPE(Vsuxei16V16VoidSF16VUVF, vsuxei16_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, ScalarFloat16, OneDUInt16, OneDFloat16)
-CUSTOM_OP_TYPE(Vsuxei32V16VoidSF16VUVF, vsuxei32_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, ScalarFloat16, OneDUInt32, OneDFloat16)
-CUSTOM_OP_TYPE(Vsuxei64V16VoidSF16VUVF, vsuxei64_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, ScalarFloat16, OneDUInt64, OneDFloat16)
-CUSTOM_OP_TYPE(Vsuxei8V32VoidSF32VUVF, vsuxei8_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, ScalarFloat32, OneDUInt8, OneDFloat32)
-CUSTOM_OP_TYPE(Vsuxei16V32VoidSF32VUVF, vsuxei16_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, ScalarFloat32, OneDUInt16, OneDFloat32)
-CUSTOM_OP_TYPE(Vsuxei32V32VoidSF32VUVF, vsuxei32_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, ScalarFloat32, OneDUInt32, OneDFloat32)
-CUSTOM_OP_TYPE(Vsuxei64V32VoidSF32VUVF, vsuxei64_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, ScalarFloat32, OneDUInt64, OneDFloat32)
-CUSTOM_OP_TYPE(Vsuxei8V64VoidSF64VUVF, vsuxei8_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, ScalarFloat64, OneDUInt8, OneDFloat64)
-CUSTOM_OP_TYPE(Vsuxei16V64VoidSF64VUVF, vsuxei16_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, ScalarFloat64, OneDUInt16, OneDFloat64)
-CUSTOM_OP_TYPE(Vsuxei32V64VoidSF64VUVF, vsuxei32_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, ScalarFloat64, OneDUInt32, OneDFloat64)
-CUSTOM_OP_TYPE(Vsuxei64V64VoidSF64VUVF, vsuxei64_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, ScalarFloat64, OneDUInt64, OneDFloat64)
-CUSTOM_OP_TYPE(Vsoxei8V8VoidSIVUVI, vsoxei8_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, ScalarInt8, OneDUInt8, OneDInt8)
-CUSTOM_OP_TYPE(Vsoxei16V8VoidSIVUVI, vsoxei16_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, ScalarInt8, OneDUInt16, OneDInt8)
-CUSTOM_OP_TYPE(Vsoxei32V8VoidSIVUVI, vsoxei32_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, ScalarInt8, OneDUInt32, OneDInt8)
-CUSTOM_OP_TYPE(Vsoxei64V8VoidSIVUVI, vsoxei64_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, ScalarInt8, OneDUInt64, OneDInt8)
-CUSTOM_OP_TYPE(Vsoxei8V16VoidSIVUVI, vsoxei8_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, ScalarInt16, OneDUInt8, OneDInt16)
-CUSTOM_OP_TYPE(Vsoxei16V16VoidSIVUVI, vsoxei16_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, ScalarInt16, OneDUInt16, OneDInt16)
-CUSTOM_OP_TYPE(Vsoxei32V16VoidSIVUVI, vsoxei32_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, ScalarInt16, OneDUInt32, OneDInt16)
-CUSTOM_OP_TYPE(Vsoxei64V16VoidSIVUVI, vsoxei64_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, ScalarInt16, OneDUInt64, OneDInt16)
-CUSTOM_OP_TYPE(Vsoxei8V32VoidSIVUVI, vsoxei8_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, ScalarInt32, OneDUInt8, OneDInt32)
-CUSTOM_OP_TYPE(Vsoxei16V32VoidSIVUVI, vsoxei16_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, ScalarInt32, OneDUInt16, OneDInt32)
-CUSTOM_OP_TYPE(Vsoxei32V32VoidSIVUVI, vsoxei32_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, ScalarInt32, OneDUInt32, OneDInt32)
-CUSTOM_OP_TYPE(Vsoxei64V32VoidSIVUVI, vsoxei64_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, ScalarInt32, OneDUInt64, OneDInt32)
-CUSTOM_OP_TYPE(Vsoxei8V64VoidSIVUVI, vsoxei8_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, ScalarInt64, OneDUInt8, OneDInt64)
-CUSTOM_OP_TYPE(Vsoxei16V64VoidSIVUVI, vsoxei16_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, ScalarInt64, OneDUInt16, OneDInt64)
-CUSTOM_OP_TYPE(Vsoxei32V64VoidSIVUVI, vsoxei32_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, ScalarInt64, OneDUInt32, OneDInt64)
-CUSTOM_OP_TYPE(Vsoxei64V64VoidSIVUVI, vsoxei64_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, ScalarInt64, OneDUInt64, OneDInt64)
-CUSTOM_OP_TYPE(Vsuxei8V8VoidSIVUVI, vsuxei8_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, ScalarInt8, OneDUInt8, OneDInt8)
-CUSTOM_OP_TYPE(Vsuxei16V8VoidSIVUVI, vsuxei16_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, ScalarInt8, OneDUInt16, OneDInt8)
-CUSTOM_OP_TYPE(Vsuxei32V8VoidSIVUVI, vsuxei32_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, ScalarInt8, OneDUInt32, OneDInt8)
-CUSTOM_OP_TYPE(Vsuxei64V8VoidSIVUVI, vsuxei64_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, ScalarInt8, OneDUInt64, OneDInt8)
-CUSTOM_OP_TYPE(Vsuxei8V16VoidSIVUVI, vsuxei8_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, ScalarInt16, OneDUInt8, OneDInt16)
-CUSTOM_OP_TYPE(Vsuxei16V16VoidSIVUVI, vsuxei16_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, ScalarInt16, OneDUInt16, OneDInt16)
-CUSTOM_OP_TYPE(Vsuxei32V16VoidSIVUVI, vsuxei32_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, ScalarInt16, OneDUInt32, OneDInt16)
-CUSTOM_OP_TYPE(Vsuxei64V16VoidSIVUVI, vsuxei64_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, ScalarInt16, OneDUInt64, OneDInt16)
-CUSTOM_OP_TYPE(Vsuxei8V32VoidSIVUVI, vsuxei8_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, ScalarInt32, OneDUInt8, OneDInt32)
-CUSTOM_OP_TYPE(Vsuxei16V32VoidSIVUVI, vsuxei16_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, ScalarInt32, OneDUInt16, OneDInt32)
-CUSTOM_OP_TYPE(Vsuxei32V32VoidSIVUVI, vsuxei32_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, ScalarInt32, OneDUInt32, OneDInt32)
-CUSTOM_OP_TYPE(Vsuxei64V32VoidSIVUVI, vsuxei64_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, ScalarInt32, OneDUInt64, OneDInt32)
-CUSTOM_OP_TYPE(Vsuxei8V64VoidSIVUVI, vsuxei8_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, ScalarInt64, OneDUInt8, OneDInt64)
-CUSTOM_OP_TYPE(Vsuxei16V64VoidSIVUVI, vsuxei16_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, ScalarInt64, OneDUInt16, OneDInt64)
-CUSTOM_OP_TYPE(Vsuxei32V64VoidSIVUVI, vsuxei32_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, ScalarInt64, OneDUInt32, OneDInt64)
-CUSTOM_OP_TYPE(Vsuxei64V64VoidSIVUVI, vsuxei64_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, ScalarInt64, OneDUInt64, OneDInt64)
-CUSTOM_OP_TYPE(Vsoxei8V8VoidSUVUVU, vsoxei8_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, ScalarUInt8, OneDUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(Vsoxei16V8VoidSUVUVU, vsoxei16_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, ScalarUInt8, OneDUInt16, OneDUInt8)
-CUSTOM_OP_TYPE(Vsoxei32V8VoidSUVUVU, vsoxei32_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, ScalarUInt8, OneDUInt32, OneDUInt8)
-CUSTOM_OP_TYPE(Vsoxei64V8VoidSUVUVU, vsoxei64_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, ScalarUInt8, OneDUInt64, OneDUInt8)
-CUSTOM_OP_TYPE(Vsoxei8V16VoidSUVUVU, vsoxei8_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, ScalarUInt16, OneDUInt8, OneDUInt16)
-CUSTOM_OP_TYPE(Vsoxei16V16VoidSUVUVU, vsoxei16_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, ScalarUInt16, OneDUInt16, OneDUInt16)
-CUSTOM_OP_TYPE(Vsoxei32V16VoidSUVUVU, vsoxei32_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, ScalarUInt16, OneDUInt32, OneDUInt16)
-CUSTOM_OP_TYPE(Vsoxei64V16VoidSUVUVU, vsoxei64_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, ScalarUInt16, OneDUInt64, OneDUInt16)
-CUSTOM_OP_TYPE(Vsoxei8V32VoidSUVUVU, vsoxei8_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, ScalarUInt32, OneDUInt8, OneDUInt32)
-CUSTOM_OP_TYPE(Vsoxei16V32VoidSUVUVU, vsoxei16_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, ScalarUInt32, OneDUInt16, OneDUInt32)
-CUSTOM_OP_TYPE(Vsoxei32V32VoidSUVUVU, vsoxei32_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, ScalarUInt32, OneDUInt32, OneDUInt32)
-CUSTOM_OP_TYPE(Vsoxei64V32VoidSUVUVU, vsoxei64_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, ScalarUInt32, OneDUInt64, OneDUInt32)
-CUSTOM_OP_TYPE(Vsoxei8V64VoidSUVUVU, vsoxei8_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, ScalarUInt64, OneDUInt8, OneDUInt64)
-CUSTOM_OP_TYPE(Vsoxei16V64VoidSUVUVU, vsoxei16_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, ScalarUInt64, OneDUInt16, OneDUInt64)
-CUSTOM_OP_TYPE(Vsoxei32V64VoidSUVUVU, vsoxei32_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, ScalarUInt64, OneDUInt32, OneDUInt64)
-CUSTOM_OP_TYPE(Vsoxei64V64VoidSUVUVU, vsoxei64_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, ScalarUInt64, OneDUInt64, OneDUInt64)
-CUSTOM_OP_TYPE(Vsuxei8V8VoidSUVUVU, vsuxei8_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, ScalarUInt8, OneDUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(Vsuxei16V8VoidSUVUVU, vsuxei16_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, ScalarUInt8, OneDUInt16, OneDUInt8)
-CUSTOM_OP_TYPE(Vsuxei32V8VoidSUVUVU, vsuxei32_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, ScalarUInt8, OneDUInt32, OneDUInt8)
-CUSTOM_OP_TYPE(Vsuxei64V8VoidSUVUVU, vsuxei64_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, ScalarUInt8, OneDUInt64, OneDUInt8)
-CUSTOM_OP_TYPE(Vsuxei8V16VoidSUVUVU, vsuxei8_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, ScalarUInt16, OneDUInt8, OneDUInt16)
-CUSTOM_OP_TYPE(Vsuxei16V16VoidSUVUVU, vsuxei16_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, ScalarUInt16, OneDUInt16, OneDUInt16)
-CUSTOM_OP_TYPE(Vsuxei32V16VoidSUVUVU, vsuxei32_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, ScalarUInt16, OneDUInt32, OneDUInt16)
-CUSTOM_OP_TYPE(Vsuxei64V16VoidSUVUVU, vsuxei64_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, ScalarUInt16, OneDUInt64, OneDUInt16)
-CUSTOM_OP_TYPE(Vsuxei8V32VoidSUVUVU, vsuxei8_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, ScalarUInt32, OneDUInt8, OneDUInt32)
-CUSTOM_OP_TYPE(Vsuxei16V32VoidSUVUVU, vsuxei16_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, ScalarUInt32, OneDUInt16, OneDUInt32)
-CUSTOM_OP_TYPE(Vsuxei32V32VoidSUVUVU, vsuxei32_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, ScalarUInt32, OneDUInt32, OneDUInt32)
-CUSTOM_OP_TYPE(Vsuxei64V32VoidSUVUVU, vsuxei64_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, ScalarUInt32, OneDUInt64, OneDUInt32)
-CUSTOM_OP_TYPE(Vsuxei8V64VoidSUVUVU, vsuxei8_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, ScalarUInt64, OneDUInt8, OneDUInt64)
-CUSTOM_OP_TYPE(Vsuxei16V64VoidSUVUVU, vsuxei16_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, ScalarUInt64, OneDUInt16, OneDUInt64)
-CUSTOM_OP_TYPE(Vsuxei32V64VoidSUVUVU, vsuxei32_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, ScalarUInt64, OneDUInt32, OneDUInt64)
-CUSTOM_OP_TYPE(Vsuxei64V64VoidSUVUVU, vsuxei64_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, ScalarUInt64, OneDUInt64, OneDUInt64)
-CUSTOM_OP_TYPE(Vsoxei8V16VoidVBSF16VUVF_m, vsoxei8_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 4, OneDBool, ScalarFloat16, OneDUInt8, OneDFloat16)
-CUSTOM_OP_TYPE(Vsoxei16V16VoidVBSF16VUVF_m, vsoxei16_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 4, OneDBool, ScalarFloat16, OneDUInt16, OneDFloat16)
-CUSTOM_OP_TYPE(Vsoxei32V16VoidVBSF16VUVF_m, vsoxei32_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 4, OneDBool, ScalarFloat16, OneDUInt32, OneDFloat16)
-CUSTOM_OP_TYPE(Vsoxei64V16VoidVBSF16VUVF_m, vsoxei64_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 4, OneDBool, ScalarFloat16, OneDUInt64, OneDFloat16)
-CUSTOM_OP_TYPE(Vsoxei8V32VoidVBSF32VUVF_m, vsoxei8_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 4, OneDBool, ScalarFloat32, OneDUInt8, OneDFloat32)
-CUSTOM_OP_TYPE(Vsoxei16V32VoidVBSF32VUVF_m, vsoxei16_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 4, OneDBool, ScalarFloat32, OneDUInt16, OneDFloat32)
-CUSTOM_OP_TYPE(Vsoxei32V32VoidVBSF32VUVF_m, vsoxei32_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 4, OneDBool, ScalarFloat32, OneDUInt32, OneDFloat32)
-CUSTOM_OP_TYPE(Vsoxei64V32VoidVBSF32VUVF_m, vsoxei64_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 4, OneDBool, ScalarFloat32, OneDUInt64, OneDFloat32)
-CUSTOM_OP_TYPE(Vsoxei8V64VoidVBSF64VUVF_m, vsoxei8_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 4, OneDBool, ScalarFloat64, OneDUInt8, OneDFloat64)
-CUSTOM_OP_TYPE(Vsoxei16V64VoidVBSF64VUVF_m, vsoxei16_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 4, OneDBool, ScalarFloat64, OneDUInt16, OneDFloat64)
-CUSTOM_OP_TYPE(Vsoxei32V64VoidVBSF64VUVF_m, vsoxei32_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 4, OneDBool, ScalarFloat64, OneDUInt32, OneDFloat64)
-CUSTOM_OP_TYPE(Vsoxei64V64VoidVBSF64VUVF_m, vsoxei64_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 4, OneDBool, ScalarFloat64, OneDUInt64, OneDFloat64)
-CUSTOM_OP_TYPE(Vsuxei8V16VoidVBSF16VUVF_m, vsuxei8_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 4, OneDBool, ScalarFloat16, OneDUInt8, OneDFloat16)
-CUSTOM_OP_TYPE(Vsuxei16V16VoidVBSF16VUVF_m, vsuxei16_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 4, OneDBool, ScalarFloat16, OneDUInt16, OneDFloat16)
-CUSTOM_OP_TYPE(Vsuxei32V16VoidVBSF16VUVF_m, vsuxei32_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 4, OneDBool, ScalarFloat16, OneDUInt32, OneDFloat16)
-CUSTOM_OP_TYPE(Vsuxei64V16VoidVBSF16VUVF_m, vsuxei64_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 4, OneDBool, ScalarFloat16, OneDUInt64, OneDFloat16)
-CUSTOM_OP_TYPE(Vsuxei8V32VoidVBSF32VUVF_m, vsuxei8_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 4, OneDBool, ScalarFloat32, OneDUInt8, OneDFloat32)
-CUSTOM_OP_TYPE(Vsuxei16V32VoidVBSF32VUVF_m, vsuxei16_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 4, OneDBool, ScalarFloat32, OneDUInt16, OneDFloat32)
-CUSTOM_OP_TYPE(Vsuxei32V32VoidVBSF32VUVF_m, vsuxei32_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 4, OneDBool, ScalarFloat32, OneDUInt32, OneDFloat32)
-CUSTOM_OP_TYPE(Vsuxei64V32VoidVBSF32VUVF_m, vsuxei64_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 4, OneDBool, ScalarFloat32, OneDUInt64, OneDFloat32)
-CUSTOM_OP_TYPE(Vsuxei8V64VoidVBSF64VUVF_m, vsuxei8_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 4, OneDBool, ScalarFloat64, OneDUInt8, OneDFloat64)
-CUSTOM_OP_TYPE(Vsuxei16V64VoidVBSF64VUVF_m, vsuxei16_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 4, OneDBool, ScalarFloat64, OneDUInt16, OneDFloat64)
-CUSTOM_OP_TYPE(Vsuxei32V64VoidVBSF64VUVF_m, vsuxei32_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 4, OneDBool, ScalarFloat64, OneDUInt32, OneDFloat64)
-CUSTOM_OP_TYPE(Vsuxei64V64VoidVBSF64VUVF_m, vsuxei64_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 4, OneDBool, ScalarFloat64, OneDUInt64, OneDFloat64)
-CUSTOM_OP_TYPE(Vsoxei8V8VoidVBSIVUVI_m, vsoxei8_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 4, OneDBool, ScalarInt8, OneDUInt8, OneDInt8)
-CUSTOM_OP_TYPE(Vsoxei16V8VoidVBSIVUVI_m, vsoxei16_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 4, OneDBool, ScalarInt8, OneDUInt16, OneDInt8)
-CUSTOM_OP_TYPE(Vsoxei32V8VoidVBSIVUVI_m, vsoxei32_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 4, OneDBool, ScalarInt8, OneDUInt32, OneDInt8)
-CUSTOM_OP_TYPE(Vsoxei64V8VoidVBSIVUVI_m, vsoxei64_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 4, OneDBool, ScalarInt8, OneDUInt64, OneDInt8)
-CUSTOM_OP_TYPE(Vsoxei8V16VoidVBSIVUVI_m, vsoxei8_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 4, OneDBool, ScalarInt16, OneDUInt8, OneDInt16)
-CUSTOM_OP_TYPE(Vsoxei16V16VoidVBSIVUVI_m, vsoxei16_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 4, OneDBool, ScalarInt16, OneDUInt16, OneDInt16)
-CUSTOM_OP_TYPE(Vsoxei32V16VoidVBSIVUVI_m, vsoxei32_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 4, OneDBool, ScalarInt16, OneDUInt32, OneDInt16)
-CUSTOM_OP_TYPE(Vsoxei64V16VoidVBSIVUVI_m, vsoxei64_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 4, OneDBool, ScalarInt16, OneDUInt64, OneDInt16)
-CUSTOM_OP_TYPE(Vsoxei8V32VoidVBSIVUVI_m, vsoxei8_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 4, OneDBool, ScalarInt32, OneDUInt8, OneDInt32)
-CUSTOM_OP_TYPE(Vsoxei16V32VoidVBSIVUVI_m, vsoxei16_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 4, OneDBool, ScalarInt32, OneDUInt16, OneDInt32)
-CUSTOM_OP_TYPE(Vsoxei32V32VoidVBSIVUVI_m, vsoxei32_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 4, OneDBool, ScalarInt32, OneDUInt32, OneDInt32)
-CUSTOM_OP_TYPE(Vsoxei64V32VoidVBSIVUVI_m, vsoxei64_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 4, OneDBool, ScalarInt32, OneDUInt64, OneDInt32)
-CUSTOM_OP_TYPE(Vsoxei8V64VoidVBSIVUVI_m, vsoxei8_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 4, OneDBool, ScalarInt64, OneDUInt8, OneDInt64)
-CUSTOM_OP_TYPE(Vsoxei16V64VoidVBSIVUVI_m, vsoxei16_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 4, OneDBool, ScalarInt64, OneDUInt16, OneDInt64)
-CUSTOM_OP_TYPE(Vsoxei32V64VoidVBSIVUVI_m, vsoxei32_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 4, OneDBool, ScalarInt64, OneDUInt32, OneDInt64)
-CUSTOM_OP_TYPE(Vsoxei64V64VoidVBSIVUVI_m, vsoxei64_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 4, OneDBool, ScalarInt64, OneDUInt64, OneDInt64)
-CUSTOM_OP_TYPE(Vsuxei8V8VoidVBSIVUVI_m, vsuxei8_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 4, OneDBool, ScalarInt8, OneDUInt8, OneDInt8)
-CUSTOM_OP_TYPE(Vsuxei16V8VoidVBSIVUVI_m, vsuxei16_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 4, OneDBool, ScalarInt8, OneDUInt16, OneDInt8)
-CUSTOM_OP_TYPE(Vsuxei32V8VoidVBSIVUVI_m, vsuxei32_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 4, OneDBool, ScalarInt8, OneDUInt32, OneDInt8)
-CUSTOM_OP_TYPE(Vsuxei64V8VoidVBSIVUVI_m, vsuxei64_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 4, OneDBool, ScalarInt8, OneDUInt64, OneDInt8)
-CUSTOM_OP_TYPE(Vsuxei8V16VoidVBSIVUVI_m, vsuxei8_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 4, OneDBool, ScalarInt16, OneDUInt8, OneDInt16)
-CUSTOM_OP_TYPE(Vsuxei16V16VoidVBSIVUVI_m, vsuxei16_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 4, OneDBool, ScalarInt16, OneDUInt16, OneDInt16)
-CUSTOM_OP_TYPE(Vsuxei32V16VoidVBSIVUVI_m, vsuxei32_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 4, OneDBool, ScalarInt16, OneDUInt32, OneDInt16)
-CUSTOM_OP_TYPE(Vsuxei64V16VoidVBSIVUVI_m, vsuxei64_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 4, OneDBool, ScalarInt16, OneDUInt64, OneDInt16)
-CUSTOM_OP_TYPE(Vsuxei8V32VoidVBSIVUVI_m, vsuxei8_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 4, OneDBool, ScalarInt32, OneDUInt8, OneDInt32)
-CUSTOM_OP_TYPE(Vsuxei16V32VoidVBSIVUVI_m, vsuxei16_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 4, OneDBool, ScalarInt32, OneDUInt16, OneDInt32)
-CUSTOM_OP_TYPE(Vsuxei32V32VoidVBSIVUVI_m, vsuxei32_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 4, OneDBool, ScalarInt32, OneDUInt32, OneDInt32)
-CUSTOM_OP_TYPE(Vsuxei64V32VoidVBSIVUVI_m, vsuxei64_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 4, OneDBool, ScalarInt32, OneDUInt64, OneDInt32)
-CUSTOM_OP_TYPE(Vsuxei8V64VoidVBSIVUVI_m, vsuxei8_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 4, OneDBool, ScalarInt64, OneDUInt8, OneDInt64)
-CUSTOM_OP_TYPE(Vsuxei16V64VoidVBSIVUVI_m, vsuxei16_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 4, OneDBool, ScalarInt64, OneDUInt16, OneDInt64)
-CUSTOM_OP_TYPE(Vsuxei32V64VoidVBSIVUVI_m, vsuxei32_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 4, OneDBool, ScalarInt64, OneDUInt32, OneDInt64)
-CUSTOM_OP_TYPE(Vsuxei64V64VoidVBSIVUVI_m, vsuxei64_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 4, OneDBool, ScalarInt64, OneDUInt64, OneDInt64)
-CUSTOM_OP_TYPE(Vsoxei8V8VoidVBSUVUVU_m, vsoxei8_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 4, OneDBool, ScalarUInt8, OneDUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(Vsoxei16V8VoidVBSUVUVU_m, vsoxei16_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 4, OneDBool, ScalarUInt8, OneDUInt16, OneDUInt8)
-CUSTOM_OP_TYPE(Vsoxei32V8VoidVBSUVUVU_m, vsoxei32_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 4, OneDBool, ScalarUInt8, OneDUInt32, OneDUInt8)
-CUSTOM_OP_TYPE(Vsoxei64V8VoidVBSUVUVU_m, vsoxei64_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 4, OneDBool, ScalarUInt8, OneDUInt64, OneDUInt8)
-CUSTOM_OP_TYPE(Vsoxei8V16VoidVBSUVUVU_m, vsoxei8_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 4, OneDBool, ScalarUInt16, OneDUInt8, OneDUInt16)
-CUSTOM_OP_TYPE(Vsoxei16V16VoidVBSUVUVU_m, vsoxei16_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 4, OneDBool, ScalarUInt16, OneDUInt16, OneDUInt16)
-CUSTOM_OP_TYPE(Vsoxei32V16VoidVBSUVUVU_m, vsoxei32_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 4, OneDBool, ScalarUInt16, OneDUInt32, OneDUInt16)
-CUSTOM_OP_TYPE(Vsoxei64V16VoidVBSUVUVU_m, vsoxei64_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 4, OneDBool, ScalarUInt16, OneDUInt64, OneDUInt16)
-CUSTOM_OP_TYPE(Vsoxei8V32VoidVBSUVUVU_m, vsoxei8_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 4, OneDBool, ScalarUInt32, OneDUInt8, OneDUInt32)
-CUSTOM_OP_TYPE(Vsoxei16V32VoidVBSUVUVU_m, vsoxei16_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 4, OneDBool, ScalarUInt32, OneDUInt16, OneDUInt32)
-CUSTOM_OP_TYPE(Vsoxei32V32VoidVBSUVUVU_m, vsoxei32_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 4, OneDBool, ScalarUInt32, OneDUInt32, OneDUInt32)
-CUSTOM_OP_TYPE(Vsoxei64V32VoidVBSUVUVU_m, vsoxei64_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 4, OneDBool, ScalarUInt32, OneDUInt64, OneDUInt32)
-CUSTOM_OP_TYPE(Vsoxei8V64VoidVBSUVUVU_m, vsoxei8_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 4, OneDBool, ScalarUInt64, OneDUInt8, OneDUInt64)
-CUSTOM_OP_TYPE(Vsoxei16V64VoidVBSUVUVU_m, vsoxei16_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 4, OneDBool, ScalarUInt64, OneDUInt16, OneDUInt64)
-CUSTOM_OP_TYPE(Vsoxei32V64VoidVBSUVUVU_m, vsoxei32_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 4, OneDBool, ScalarUInt64, OneDUInt32, OneDUInt64)
-CUSTOM_OP_TYPE(Vsoxei64V64VoidVBSUVUVU_m, vsoxei64_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 4, OneDBool, ScalarUInt64, OneDUInt64, OneDUInt64)
-CUSTOM_OP_TYPE(Vsuxei8V8VoidVBSUVUVU_m, vsuxei8_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 4, OneDBool, ScalarUInt8, OneDUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(Vsuxei16V8VoidVBSUVUVU_m, vsuxei16_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 4, OneDBool, ScalarUInt8, OneDUInt16, OneDUInt8)
-CUSTOM_OP_TYPE(Vsuxei32V8VoidVBSUVUVU_m, vsuxei32_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 4, OneDBool, ScalarUInt8, OneDUInt32, OneDUInt8)
-CUSTOM_OP_TYPE(Vsuxei64V8VoidVBSUVUVU_m, vsuxei64_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 4, OneDBool, ScalarUInt8, OneDUInt64, OneDUInt8)
-CUSTOM_OP_TYPE(Vsuxei8V16VoidVBSUVUVU_m, vsuxei8_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 4, OneDBool, ScalarUInt16, OneDUInt8, OneDUInt16)
-CUSTOM_OP_TYPE(Vsuxei16V16VoidVBSUVUVU_m, vsuxei16_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 4, OneDBool, ScalarUInt16, OneDUInt16, OneDUInt16)
-CUSTOM_OP_TYPE(Vsuxei32V16VoidVBSUVUVU_m, vsuxei32_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 4, OneDBool, ScalarUInt16, OneDUInt32, OneDUInt16)
-CUSTOM_OP_TYPE(Vsuxei64V16VoidVBSUVUVU_m, vsuxei64_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 4, OneDBool, ScalarUInt16, OneDUInt64, OneDUInt16)
-CUSTOM_OP_TYPE(Vsuxei8V32VoidVBSUVUVU_m, vsuxei8_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 4, OneDBool, ScalarUInt32, OneDUInt8, OneDUInt32)
-CUSTOM_OP_TYPE(Vsuxei16V32VoidVBSUVUVU_m, vsuxei16_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 4, OneDBool, ScalarUInt32, OneDUInt16, OneDUInt32)
-CUSTOM_OP_TYPE(Vsuxei32V32VoidVBSUVUVU_m, vsuxei32_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 4, OneDBool, ScalarUInt32, OneDUInt32, OneDUInt32)
-CUSTOM_OP_TYPE(Vsuxei64V32VoidVBSUVUVU_m, vsuxei64_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 4, OneDBool, ScalarUInt32, OneDUInt64, OneDUInt32)
-CUSTOM_OP_TYPE(Vsuxei8V64VoidVBSUVUVU_m, vsuxei8_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 4, OneDBool, ScalarUInt64, OneDUInt8, OneDUInt64)
-CUSTOM_OP_TYPE(Vsuxei16V64VoidVBSUVUVU_m, vsuxei16_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 4, OneDBool, ScalarUInt64, OneDUInt16, OneDUInt64)
-CUSTOM_OP_TYPE(Vsuxei32V64VoidVBSUVUVU_m, vsuxei32_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 4, OneDBool, ScalarUInt64, OneDUInt32, OneDUInt64)
-CUSTOM_OP_TYPE(Vsuxei64V64VoidVBSUVUVU_m, vsuxei64_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 4, OneDBool, ScalarUInt64, OneDUInt64, OneDUInt64)
-CUSTOM_OP_TYPE(Vle16ffX16VFloat16SF16SZP, le16ff_x, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, SizePtr)
-CUSTOM_OP_TYPE(Vle32ffX32VFloat32SF32SZP, le32ff_x, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, SizePtr)
-CUSTOM_OP_TYPE(Vle64ffX64VFloat64SF64SZP, le64ff_x, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, SizePtr)
-CUSTOM_OP_TYPE(Vle8ffX8VInt8SISZP, le8ff_x, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, SizePtr)
-CUSTOM_OP_TYPE(Vle16ffX16VInt16SISZP, le16ff_x, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, SizePtr)
-CUSTOM_OP_TYPE(Vle32ffX32VInt32SISZP, le32ff_x, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, SizePtr)
-CUSTOM_OP_TYPE(Vle64ffX64VInt64SISZP, le64ff_x, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, SizePtr)
-CUSTOM_OP_TYPE(Vle8ffX8VUInt8SUSZP, le8ff_x, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, SizePtr)
-CUSTOM_OP_TYPE(Vle16ffX16VUInt16SUSZP, le16ff_x, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, SizePtr)
-CUSTOM_OP_TYPE(Vle32ffX32VUInt32SUSZP, le32ff_x, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, SizePtr)
-CUSTOM_OP_TYPE(Vle64ffX64VUInt64SUSZP, le64ff_x, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, SizePtr)
-CUSTOM_OP_TYPE(Vle16ffX16VFloat16VBSF16SZP_m, le16ff_x, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, SizePtr)
-CUSTOM_OP_TYPE(Vle32ffX32VFloat32VBSF32SZP_m, le32ff_x, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, SizePtr)
-CUSTOM_OP_TYPE(Vle64ffX64VFloat64VBSF64SZP_m, le64ff_x, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, SizePtr)
-CUSTOM_OP_TYPE(Vle8ffX8VInt8VBSISZP_m, le8ff_x, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, SizePtr)
-CUSTOM_OP_TYPE(Vle16ffX16VInt16VBSISZP_m, le16ff_x, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, SizePtr)
-CUSTOM_OP_TYPE(Vle32ffX32VInt32VBSISZP_m, le32ff_x, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, SizePtr)
-CUSTOM_OP_TYPE(Vle64ffX64VInt64VBSISZP_m, le64ff_x, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, SizePtr)
-CUSTOM_OP_TYPE(Vle8ffX8VUInt8VBSUSZP_m, le8ff_x, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, SizePtr)
-CUSTOM_OP_TYPE(Vle16ffX16VUInt16VBSUSZP_m, le16ff_x, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, SizePtr)
-CUSTOM_OP_TYPE(Vle32ffX32VUInt32VBSUSZP_m, le32ff_x, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, SizePtr)
-CUSTOM_OP_TYPE(Vle64ffX64VUInt64VBSUSZP_m, le64ff_x, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, SizePtr)
+CUSTOM_OP_TYPE(Lse16XX16VFloat16SF16SI, lse16_xx, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse32XX32VFloat32SF32SI, lse32_xx, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse64XX64VFloat64SF64SI, lse64_xx, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse8XX8VInt8SISI, lse8_xx, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse16XX16VInt16SISI, lse16_xx, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse32XX32VInt32SISI, lse32_xx, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse64XX64VInt64SISI, lse64_xx, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse8XX8VUInt8SUSI, lse8_xx, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse16XX16VUInt16SUSI, lse16_xx, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse32XX32VUInt32SUSI, lse32_xx, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse64XX64VUInt64SUSI, lse64_xx, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse16XX16VFloat16VBSF16SI_m, lse16_xx, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse32XX32VFloat32VBSF32SI_m, lse32_xx, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse64XX64VFloat64VBSF64SI_m, lse64_xx, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse8XX8VInt8VBSISI_m, lse8_xx, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse16XX16VInt16VBSISI_m, lse16_xx, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse32XX32VInt32VBSISI_m, lse32_xx, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse64XX64VInt64VBSISI_m, lse64_xx, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse8XX8VUInt8VBSUSI_m, lse8_xx, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse16XX16VUInt16VBSUSI_m, lse16_xx, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse32XX32VUInt32VBSUSI_m, lse32_xx, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, ScalarIntXLen)
+CUSTOM_OP_TYPE(Lse64XX64VUInt64VBSUSI_m, lse64_xx, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, ScalarIntXLen)
+CUSTOM_OP_TYPE(Sse16XX16VoidSF16SIVF, sse16_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, ScalarFloat16, ScalarIntXLen, OneDFloat16)
+CUSTOM_OP_TYPE(Sse32XX32VoidSF32SIVF, sse32_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, ScalarFloat32, ScalarIntXLen, OneDFloat32)
+CUSTOM_OP_TYPE(Sse64XX64VoidSF64SIVF, sse64_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, ScalarFloat64, ScalarIntXLen, OneDFloat64)
+CUSTOM_OP_TYPE(Sse8XX8VoidSISIVI, sse8_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, ScalarInt8, ScalarIntXLen, OneDInt8)
+CUSTOM_OP_TYPE(Sse16XX16VoidSISIVI, sse16_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, ScalarInt16, ScalarIntXLen, OneDInt16)
+CUSTOM_OP_TYPE(Sse32XX32VoidSISIVI, sse32_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, ScalarInt32, ScalarIntXLen, OneDInt32)
+CUSTOM_OP_TYPE(Sse64XX64VoidSISIVI, sse64_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, ScalarInt64, ScalarIntXLen, OneDInt64)
+CUSTOM_OP_TYPE(Sse8XX8VoidSUSIVU, sse8_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, ScalarUInt8, ScalarIntXLen, OneDUInt8)
+CUSTOM_OP_TYPE(Sse16XX16VoidSUSIVU, sse16_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, ScalarUInt16, ScalarIntXLen, OneDUInt16)
+CUSTOM_OP_TYPE(Sse32XX32VoidSUSIVU, sse32_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, ScalarUInt32, ScalarIntXLen, OneDUInt32)
+CUSTOM_OP_TYPE(Sse64XX64VoidSUSIVU, sse64_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, ScalarUInt64, ScalarIntXLen, OneDUInt64)
+CUSTOM_OP_TYPE(Sse16XX16VoidVBSF16SIVF_m, sse16_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 4, OneDBool, ScalarFloat16, ScalarIntXLen, OneDFloat16)
+CUSTOM_OP_TYPE(Sse32XX32VoidVBSF32SIVF_m, sse32_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 4, OneDBool, ScalarFloat32, ScalarIntXLen, OneDFloat32)
+CUSTOM_OP_TYPE(Sse64XX64VoidVBSF64SIVF_m, sse64_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 4, OneDBool, ScalarFloat64, ScalarIntXLen, OneDFloat64)
+CUSTOM_OP_TYPE(Sse8XX8VoidVBSISIVI_m, sse8_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 4, OneDBool, ScalarInt8, ScalarIntXLen, OneDInt8)
+CUSTOM_OP_TYPE(Sse16XX16VoidVBSISIVI_m, sse16_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 4, OneDBool, ScalarInt16, ScalarIntXLen, OneDInt16)
+CUSTOM_OP_TYPE(Sse32XX32VoidVBSISIVI_m, sse32_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 4, OneDBool, ScalarInt32, ScalarIntXLen, OneDInt32)
+CUSTOM_OP_TYPE(Sse64XX64VoidVBSISIVI_m, sse64_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 4, OneDBool, ScalarInt64, ScalarIntXLen, OneDInt64)
+CUSTOM_OP_TYPE(Sse8XX8VoidVBSUSIVU_m, sse8_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 4, OneDBool, ScalarUInt8, ScalarIntXLen, OneDUInt8)
+CUSTOM_OP_TYPE(Sse16XX16VoidVBSUSIVU_m, sse16_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 4, OneDBool, ScalarUInt16, ScalarIntXLen, OneDUInt16)
+CUSTOM_OP_TYPE(Sse32XX32VoidVBSUSIVU_m, sse32_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 4, OneDBool, ScalarUInt32, ScalarIntXLen, OneDUInt32)
+CUSTOM_OP_TYPE(Sse64XX64VoidVBSUSIVU_m, sse64_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 4, OneDBool, ScalarUInt64, ScalarIntXLen, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V16VFloat16SF16VU, loxei8_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V16VFloat16SF16VU, loxei16_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V16VFloat16SF16VU, loxei32_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V16VFloat16SF16VU, loxei64_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V32VFloat32SF32VU, loxei8_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V32VFloat32SF32VU, loxei16_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V32VFloat32SF32VU, loxei32_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V32VFloat32SF32VU, loxei64_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V64VFloat64SF64VU, loxei8_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V64VFloat64SF64VU, loxei16_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V64VFloat64SF64VU, loxei32_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V64VFloat64SF64VU, loxei64_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V16VFloat16SF16VU, luxei8_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V16VFloat16SF16VU, luxei16_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V16VFloat16SF16VU, luxei32_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V16VFloat16SF16VU, luxei64_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V32VFloat32SF32VU, luxei8_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V32VFloat32SF32VU, luxei16_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V32VFloat32SF32VU, luxei32_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V32VFloat32SF32VU, luxei64_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V64VFloat64SF64VU, luxei8_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V64VFloat64SF64VU, luxei16_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V64VFloat64SF64VU, luxei32_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V64VFloat64SF64VU, luxei64_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V8VInt8SIVU, loxei8_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V8VInt8SIVU, loxei16_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V8VInt8SIVU, loxei32_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V8VInt8SIVU, loxei64_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V16VInt16SIVU, loxei8_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V16VInt16SIVU, loxei16_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V16VInt16SIVU, loxei32_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V16VInt16SIVU, loxei64_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V32VInt32SIVU, loxei8_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V32VInt32SIVU, loxei16_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V32VInt32SIVU, loxei32_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V32VInt32SIVU, loxei64_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V64VInt64SIVU, loxei8_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V64VInt64SIVU, loxei16_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V64VInt64SIVU, loxei32_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V64VInt64SIVU, loxei64_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V8VInt8SIVU, luxei8_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V8VInt8SIVU, luxei16_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V8VInt8SIVU, luxei32_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V8VInt8SIVU, luxei64_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V16VInt16SIVU, luxei8_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V16VInt16SIVU, luxei16_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V16VInt16SIVU, luxei32_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V16VInt16SIVU, luxei64_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V32VInt32SIVU, luxei8_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V32VInt32SIVU, luxei16_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V32VInt32SIVU, luxei32_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V32VInt32SIVU, luxei64_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V64VInt64SIVU, luxei8_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V64VInt64SIVU, luxei16_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V64VInt64SIVU, luxei32_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V64VInt64SIVU, luxei64_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V8VUInt8SUVU, loxei8_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V8VUInt8SUVU, loxei16_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V8VUInt8SUVU, loxei32_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V8VUInt8SUVU, loxei64_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V16VUInt16SUVU, loxei8_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V16VUInt16SUVU, loxei16_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V16VUInt16SUVU, loxei32_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V16VUInt16SUVU, loxei64_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V32VUInt32SUVU, loxei8_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V32VUInt32SUVU, loxei16_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V32VUInt32SUVU, loxei32_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V32VUInt32SUVU, loxei64_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V64VUInt64SUVU, loxei8_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V64VUInt64SUVU, loxei16_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V64VUInt64SUVU, loxei32_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V64VUInt64SUVU, loxei64_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V8VUInt8SUVU, luxei8_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V8VUInt8SUVU, luxei16_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V8VUInt8SUVU, luxei32_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V8VUInt8SUVU, luxei64_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V16VUInt16SUVU, luxei8_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V16VUInt16SUVU, luxei16_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V16VUInt16SUVU, luxei32_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V16VUInt16SUVU, luxei64_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V32VUInt32SUVU, luxei8_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V32VUInt32SUVU, luxei16_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V32VUInt32SUVU, luxei32_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V32VUInt32SUVU, luxei64_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V64VUInt64SUVU, luxei8_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V64VUInt64SUVU, luxei16_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V64VUInt64SUVU, luxei32_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V64VUInt64SUVU, luxei64_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V16VFloat16VBSF16VU_m, loxei8_v, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V16VFloat16VBSF16VU_m, loxei16_v, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V16VFloat16VBSF16VU_m, loxei32_v, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V16VFloat16VBSF16VU_m, loxei64_v, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V32VFloat32VBSF32VU_m, loxei8_v, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V32VFloat32VBSF32VU_m, loxei16_v, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V32VFloat32VBSF32VU_m, loxei32_v, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V32VFloat32VBSF32VU_m, loxei64_v, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V64VFloat64VBSF64VU_m, loxei8_v, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V64VFloat64VBSF64VU_m, loxei16_v, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V64VFloat64VBSF64VU_m, loxei32_v, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V64VFloat64VBSF64VU_m, loxei64_v, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V16VFloat16VBSF16VU_m, luxei8_v, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V16VFloat16VBSF16VU_m, luxei16_v, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V16VFloat16VBSF16VU_m, luxei32_v, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V16VFloat16VBSF16VU_m, luxei64_v, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V32VFloat32VBSF32VU_m, luxei8_v, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V32VFloat32VBSF32VU_m, luxei16_v, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V32VFloat32VBSF32VU_m, luxei32_v, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V32VFloat32VBSF32VU_m, luxei64_v, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V64VFloat64VBSF64VU_m, luxei8_v, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V64VFloat64VBSF64VU_m, luxei16_v, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V64VFloat64VBSF64VU_m, luxei32_v, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V64VFloat64VBSF64VU_m, luxei64_v, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V8VInt8VBSIVU_m, loxei8_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V8VInt8VBSIVU_m, loxei16_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V8VInt8VBSIVU_m, loxei32_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V8VInt8VBSIVU_m, loxei64_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V16VInt16VBSIVU_m, loxei8_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V16VInt16VBSIVU_m, loxei16_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V16VInt16VBSIVU_m, loxei32_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V16VInt16VBSIVU_m, loxei64_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V32VInt32VBSIVU_m, loxei8_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V32VInt32VBSIVU_m, loxei16_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V32VInt32VBSIVU_m, loxei32_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V32VInt32VBSIVU_m, loxei64_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V64VInt64VBSIVU_m, loxei8_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V64VInt64VBSIVU_m, loxei16_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V64VInt64VBSIVU_m, loxei32_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V64VInt64VBSIVU_m, loxei64_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V8VInt8VBSIVU_m, luxei8_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V8VInt8VBSIVU_m, luxei16_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V8VInt8VBSIVU_m, luxei32_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V8VInt8VBSIVU_m, luxei64_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V16VInt16VBSIVU_m, luxei8_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V16VInt16VBSIVU_m, luxei16_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V16VInt16VBSIVU_m, luxei32_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V16VInt16VBSIVU_m, luxei64_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V32VInt32VBSIVU_m, luxei8_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V32VInt32VBSIVU_m, luxei16_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V32VInt32VBSIVU_m, luxei32_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V32VInt32VBSIVU_m, luxei64_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V64VInt64VBSIVU_m, luxei8_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V64VInt64VBSIVU_m, luxei16_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V64VInt64VBSIVU_m, luxei32_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V64VInt64VBSIVU_m, luxei64_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V8VUInt8VBSUVU_m, loxei8_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V8VUInt8VBSUVU_m, loxei16_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V8VUInt8VBSUVU_m, loxei32_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V8VUInt8VBSUVU_m, loxei64_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V16VUInt16VBSUVU_m, loxei8_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V16VUInt16VBSUVU_m, loxei16_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V16VUInt16VBSUVU_m, loxei32_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V16VUInt16VBSUVU_m, loxei64_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V32VUInt32VBSUVU_m, loxei8_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V32VUInt32VBSUVU_m, loxei16_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V32VUInt32VBSUVU_m, loxei32_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V32VUInt32VBSUVU_m, loxei64_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, OneDUInt64)
+CUSTOM_OP_TYPE(Loxei8V64VUInt64VBSUVU_m, loxei8_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, OneDUInt8)
+CUSTOM_OP_TYPE(Loxei16V64VUInt64VBSUVU_m, loxei16_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, OneDUInt16)
+CUSTOM_OP_TYPE(Loxei32V64VUInt64VBSUVU_m, loxei32_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, OneDUInt32)
+CUSTOM_OP_TYPE(Loxei64V64VUInt64VBSUVU_m, loxei64_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V8VUInt8VBSUVU_m, luxei8_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V8VUInt8VBSUVU_m, luxei16_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V8VUInt8VBSUVU_m, luxei32_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V8VUInt8VBSUVU_m, luxei64_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V16VUInt16VBSUVU_m, luxei8_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V16VUInt16VBSUVU_m, luxei16_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V16VUInt16VBSUVU_m, luxei32_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V16VUInt16VBSUVU_m, luxei64_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V32VUInt32VBSUVU_m, luxei8_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V32VUInt32VBSUVU_m, luxei16_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V32VUInt32VBSUVU_m, luxei32_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V32VUInt32VBSUVU_m, luxei64_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, OneDUInt64)
+CUSTOM_OP_TYPE(Luxei8V64VUInt64VBSUVU_m, luxei8_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, OneDUInt8)
+CUSTOM_OP_TYPE(Luxei16V64VUInt64VBSUVU_m, luxei16_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, OneDUInt16)
+CUSTOM_OP_TYPE(Luxei32V64VUInt64VBSUVU_m, luxei32_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, OneDUInt32)
+CUSTOM_OP_TYPE(Luxei64V64VUInt64VBSUVU_m, luxei64_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, OneDUInt64)
+CUSTOM_OP_TYPE(Soxei8V16VoidSF16VUVF, soxei8_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, ScalarFloat16, OneDUInt8, OneDFloat16)
+CUSTOM_OP_TYPE(Soxei16V16VoidSF16VUVF, soxei16_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, ScalarFloat16, OneDUInt16, OneDFloat16)
+CUSTOM_OP_TYPE(Soxei32V16VoidSF16VUVF, soxei32_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, ScalarFloat16, OneDUInt32, OneDFloat16)
+CUSTOM_OP_TYPE(Soxei64V16VoidSF16VUVF, soxei64_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, ScalarFloat16, OneDUInt64, OneDFloat16)
+CUSTOM_OP_TYPE(Soxei8V32VoidSF32VUVF, soxei8_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, ScalarFloat32, OneDUInt8, OneDFloat32)
+CUSTOM_OP_TYPE(Soxei16V32VoidSF32VUVF, soxei16_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, ScalarFloat32, OneDUInt16, OneDFloat32)
+CUSTOM_OP_TYPE(Soxei32V32VoidSF32VUVF, soxei32_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, ScalarFloat32, OneDUInt32, OneDFloat32)
+CUSTOM_OP_TYPE(Soxei64V32VoidSF32VUVF, soxei64_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, ScalarFloat32, OneDUInt64, OneDFloat32)
+CUSTOM_OP_TYPE(Soxei8V64VoidSF64VUVF, soxei8_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, ScalarFloat64, OneDUInt8, OneDFloat64)
+CUSTOM_OP_TYPE(Soxei16V64VoidSF64VUVF, soxei16_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, ScalarFloat64, OneDUInt16, OneDFloat64)
+CUSTOM_OP_TYPE(Soxei32V64VoidSF64VUVF, soxei32_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, ScalarFloat64, OneDUInt32, OneDFloat64)
+CUSTOM_OP_TYPE(Soxei64V64VoidSF64VUVF, soxei64_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, ScalarFloat64, OneDUInt64, OneDFloat64)
+CUSTOM_OP_TYPE(Suxei8V16VoidSF16VUVF, suxei8_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, ScalarFloat16, OneDUInt8, OneDFloat16)
+CUSTOM_OP_TYPE(Suxei16V16VoidSF16VUVF, suxei16_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, ScalarFloat16, OneDUInt16, OneDFloat16)
+CUSTOM_OP_TYPE(Suxei32V16VoidSF16VUVF, suxei32_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, ScalarFloat16, OneDUInt32, OneDFloat16)
+CUSTOM_OP_TYPE(Suxei64V16VoidSF16VUVF, suxei64_v, 16, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 3, ScalarFloat16, OneDUInt64, OneDFloat16)
+CUSTOM_OP_TYPE(Suxei8V32VoidSF32VUVF, suxei8_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, ScalarFloat32, OneDUInt8, OneDFloat32)
+CUSTOM_OP_TYPE(Suxei16V32VoidSF32VUVF, suxei16_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, ScalarFloat32, OneDUInt16, OneDFloat32)
+CUSTOM_OP_TYPE(Suxei32V32VoidSF32VUVF, suxei32_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, ScalarFloat32, OneDUInt32, OneDFloat32)
+CUSTOM_OP_TYPE(Suxei64V32VoidSF32VUVF, suxei64_v, 32, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 3, ScalarFloat32, OneDUInt64, OneDFloat32)
+CUSTOM_OP_TYPE(Suxei8V64VoidSF64VUVF, suxei8_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, ScalarFloat64, OneDUInt8, OneDFloat64)
+CUSTOM_OP_TYPE(Suxei16V64VoidSF64VUVF, suxei16_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, ScalarFloat64, OneDUInt16, OneDFloat64)
+CUSTOM_OP_TYPE(Suxei32V64VoidSF64VUVF, suxei32_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, ScalarFloat64, OneDUInt32, OneDFloat64)
+CUSTOM_OP_TYPE(Suxei64V64VoidSF64VUVF, suxei64_v, 64, FLOAT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 3, ScalarFloat64, OneDUInt64, OneDFloat64)
+CUSTOM_OP_TYPE(Soxei8V8VoidSIVUVI, soxei8_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, ScalarInt8, OneDUInt8, OneDInt8)
+CUSTOM_OP_TYPE(Soxei16V8VoidSIVUVI, soxei16_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, ScalarInt8, OneDUInt16, OneDInt8)
+CUSTOM_OP_TYPE(Soxei32V8VoidSIVUVI, soxei32_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, ScalarInt8, OneDUInt32, OneDInt8)
+CUSTOM_OP_TYPE(Soxei64V8VoidSIVUVI, soxei64_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, ScalarInt8, OneDUInt64, OneDInt8)
+CUSTOM_OP_TYPE(Soxei8V16VoidSIVUVI, soxei8_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, ScalarInt16, OneDUInt8, OneDInt16)
+CUSTOM_OP_TYPE(Soxei16V16VoidSIVUVI, soxei16_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, ScalarInt16, OneDUInt16, OneDInt16)
+CUSTOM_OP_TYPE(Soxei32V16VoidSIVUVI, soxei32_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, ScalarInt16, OneDUInt32, OneDInt16)
+CUSTOM_OP_TYPE(Soxei64V16VoidSIVUVI, soxei64_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, ScalarInt16, OneDUInt64, OneDInt16)
+CUSTOM_OP_TYPE(Soxei8V32VoidSIVUVI, soxei8_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, ScalarInt32, OneDUInt8, OneDInt32)
+CUSTOM_OP_TYPE(Soxei16V32VoidSIVUVI, soxei16_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, ScalarInt32, OneDUInt16, OneDInt32)
+CUSTOM_OP_TYPE(Soxei32V32VoidSIVUVI, soxei32_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, ScalarInt32, OneDUInt32, OneDInt32)
+CUSTOM_OP_TYPE(Soxei64V32VoidSIVUVI, soxei64_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, ScalarInt32, OneDUInt64, OneDInt32)
+CUSTOM_OP_TYPE(Soxei8V64VoidSIVUVI, soxei8_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, ScalarInt64, OneDUInt8, OneDInt64)
+CUSTOM_OP_TYPE(Soxei16V64VoidSIVUVI, soxei16_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, ScalarInt64, OneDUInt16, OneDInt64)
+CUSTOM_OP_TYPE(Soxei32V64VoidSIVUVI, soxei32_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, ScalarInt64, OneDUInt32, OneDInt64)
+CUSTOM_OP_TYPE(Soxei64V64VoidSIVUVI, soxei64_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, ScalarInt64, OneDUInt64, OneDInt64)
+CUSTOM_OP_TYPE(Suxei8V8VoidSIVUVI, suxei8_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, ScalarInt8, OneDUInt8, OneDInt8)
+CUSTOM_OP_TYPE(Suxei16V8VoidSIVUVI, suxei16_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, ScalarInt8, OneDUInt16, OneDInt8)
+CUSTOM_OP_TYPE(Suxei32V8VoidSIVUVI, suxei32_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, ScalarInt8, OneDUInt32, OneDInt8)
+CUSTOM_OP_TYPE(Suxei64V8VoidSIVUVI, suxei64_v, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt8, 3, ScalarInt8, OneDUInt64, OneDInt8)
+CUSTOM_OP_TYPE(Suxei8V16VoidSIVUVI, suxei8_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, ScalarInt16, OneDUInt8, OneDInt16)
+CUSTOM_OP_TYPE(Suxei16V16VoidSIVUVI, suxei16_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, ScalarInt16, OneDUInt16, OneDInt16)
+CUSTOM_OP_TYPE(Suxei32V16VoidSIVUVI, suxei32_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, ScalarInt16, OneDUInt32, OneDInt16)
+CUSTOM_OP_TYPE(Suxei64V16VoidSIVUVI, suxei64_v, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt16, 3, ScalarInt16, OneDUInt64, OneDInt16)
+CUSTOM_OP_TYPE(Suxei8V32VoidSIVUVI, suxei8_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, ScalarInt32, OneDUInt8, OneDInt32)
+CUSTOM_OP_TYPE(Suxei16V32VoidSIVUVI, suxei16_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, ScalarInt32, OneDUInt16, OneDInt32)
+CUSTOM_OP_TYPE(Suxei32V32VoidSIVUVI, suxei32_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, ScalarInt32, OneDUInt32, OneDInt32)
+CUSTOM_OP_TYPE(Suxei64V32VoidSIVUVI, suxei64_v, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt32, 3, ScalarInt32, OneDUInt64, OneDInt32)
+CUSTOM_OP_TYPE(Suxei8V64VoidSIVUVI, suxei8_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, ScalarInt64, OneDUInt8, OneDInt64)
+CUSTOM_OP_TYPE(Suxei16V64VoidSIVUVI, suxei16_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, ScalarInt64, OneDUInt16, OneDInt64)
+CUSTOM_OP_TYPE(Suxei32V64VoidSIVUVI, suxei32_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, ScalarInt64, OneDUInt32, OneDInt64)
+CUSTOM_OP_TYPE(Suxei64V64VoidSIVUVI, suxei64_v, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDInt64, 3, ScalarInt64, OneDUInt64, OneDInt64)
+CUSTOM_OP_TYPE(Soxei8V8VoidSUVUVU, soxei8_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, ScalarUInt8, OneDUInt8, OneDUInt8)
+CUSTOM_OP_TYPE(Soxei16V8VoidSUVUVU, soxei16_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, ScalarUInt8, OneDUInt16, OneDUInt8)
+CUSTOM_OP_TYPE(Soxei32V8VoidSUVUVU, soxei32_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, ScalarUInt8, OneDUInt32, OneDUInt8)
+CUSTOM_OP_TYPE(Soxei64V8VoidSUVUVU, soxei64_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, ScalarUInt8, OneDUInt64, OneDUInt8)
+CUSTOM_OP_TYPE(Soxei8V16VoidSUVUVU, soxei8_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, ScalarUInt16, OneDUInt8, OneDUInt16)
+CUSTOM_OP_TYPE(Soxei16V16VoidSUVUVU, soxei16_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, ScalarUInt16, OneDUInt16, OneDUInt16)
+CUSTOM_OP_TYPE(Soxei32V16VoidSUVUVU, soxei32_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, ScalarUInt16, OneDUInt32, OneDUInt16)
+CUSTOM_OP_TYPE(Soxei64V16VoidSUVUVU, soxei64_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, ScalarUInt16, OneDUInt64, OneDUInt16)
+CUSTOM_OP_TYPE(Soxei8V32VoidSUVUVU, soxei8_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, ScalarUInt32, OneDUInt8, OneDUInt32)
+CUSTOM_OP_TYPE(Soxei16V32VoidSUVUVU, soxei16_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, ScalarUInt32, OneDUInt16, OneDUInt32)
+CUSTOM_OP_TYPE(Soxei32V32VoidSUVUVU, soxei32_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, ScalarUInt32, OneDUInt32, OneDUInt32)
+CUSTOM_OP_TYPE(Soxei64V32VoidSUVUVU, soxei64_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, ScalarUInt32, OneDUInt64, OneDUInt32)
+CUSTOM_OP_TYPE(Soxei8V64VoidSUVUVU, soxei8_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, ScalarUInt64, OneDUInt8, OneDUInt64)
+CUSTOM_OP_TYPE(Soxei16V64VoidSUVUVU, soxei16_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, ScalarUInt64, OneDUInt16, OneDUInt64)
+CUSTOM_OP_TYPE(Soxei32V64VoidSUVUVU, soxei32_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, ScalarUInt64, OneDUInt32, OneDUInt64)
+CUSTOM_OP_TYPE(Soxei64V64VoidSUVUVU, soxei64_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, ScalarUInt64, OneDUInt64, OneDUInt64)
+CUSTOM_OP_TYPE(Suxei8V8VoidSUVUVU, suxei8_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, ScalarUInt8, OneDUInt8, OneDUInt8)
+CUSTOM_OP_TYPE(Suxei16V8VoidSUVUVU, suxei16_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, ScalarUInt8, OneDUInt16, OneDUInt8)
+CUSTOM_OP_TYPE(Suxei32V8VoidSUVUVU, suxei32_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, ScalarUInt8, OneDUInt32, OneDUInt8)
+CUSTOM_OP_TYPE(Suxei64V8VoidSUVUVU, suxei64_v, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 3, ScalarUInt8, OneDUInt64, OneDUInt8)
+CUSTOM_OP_TYPE(Suxei8V16VoidSUVUVU, suxei8_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, ScalarUInt16, OneDUInt8, OneDUInt16)
+CUSTOM_OP_TYPE(Suxei16V16VoidSUVUVU, suxei16_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, ScalarUInt16, OneDUInt16, OneDUInt16)
+CUSTOM_OP_TYPE(Suxei32V16VoidSUVUVU, suxei32_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, ScalarUInt16, OneDUInt32, OneDUInt16)
+CUSTOM_OP_TYPE(Suxei64V16VoidSUVUVU, suxei64_v, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 3, ScalarUInt16, OneDUInt64, OneDUInt16)
+CUSTOM_OP_TYPE(Suxei8V32VoidSUVUVU, suxei8_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, ScalarUInt32, OneDUInt8, OneDUInt32)
+CUSTOM_OP_TYPE(Suxei16V32VoidSUVUVU, suxei16_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, ScalarUInt32, OneDUInt16, OneDUInt32)
+CUSTOM_OP_TYPE(Suxei32V32VoidSUVUVU, suxei32_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, ScalarUInt32, OneDUInt32, OneDUInt32)
+CUSTOM_OP_TYPE(Suxei64V32VoidSUVUVU, suxei64_v, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 3, ScalarUInt32, OneDUInt64, OneDUInt32)
+CUSTOM_OP_TYPE(Suxei8V64VoidSUVUVU, suxei8_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, ScalarUInt64, OneDUInt8, OneDUInt64)
+CUSTOM_OP_TYPE(Suxei16V64VoidSUVUVU, suxei16_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, ScalarUInt64, OneDUInt16, OneDUInt64)
+CUSTOM_OP_TYPE(Suxei32V64VoidSUVUVU, suxei32_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, ScalarUInt64, OneDUInt32, OneDUInt64)
+CUSTOM_OP_TYPE(Suxei64V64VoidSUVUVU, suxei64_v, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 3, ScalarUInt64, OneDUInt64, OneDUInt64)
+CUSTOM_OP_TYPE(Soxei8V16VoidVBSF16VUVF_m, soxei8_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 4, OneDBool, ScalarFloat16, OneDUInt8, OneDFloat16)
+CUSTOM_OP_TYPE(Soxei16V16VoidVBSF16VUVF_m, soxei16_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 4, OneDBool, ScalarFloat16, OneDUInt16, OneDFloat16)
+CUSTOM_OP_TYPE(Soxei32V16VoidVBSF16VUVF_m, soxei32_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 4, OneDBool, ScalarFloat16, OneDUInt32, OneDFloat16)
+CUSTOM_OP_TYPE(Soxei64V16VoidVBSF16VUVF_m, soxei64_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 4, OneDBool, ScalarFloat16, OneDUInt64, OneDFloat16)
+CUSTOM_OP_TYPE(Soxei8V32VoidVBSF32VUVF_m, soxei8_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 4, OneDBool, ScalarFloat32, OneDUInt8, OneDFloat32)
+CUSTOM_OP_TYPE(Soxei16V32VoidVBSF32VUVF_m, soxei16_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 4, OneDBool, ScalarFloat32, OneDUInt16, OneDFloat32)
+CUSTOM_OP_TYPE(Soxei32V32VoidVBSF32VUVF_m, soxei32_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 4, OneDBool, ScalarFloat32, OneDUInt32, OneDFloat32)
+CUSTOM_OP_TYPE(Soxei64V32VoidVBSF32VUVF_m, soxei64_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 4, OneDBool, ScalarFloat32, OneDUInt64, OneDFloat32)
+CUSTOM_OP_TYPE(Soxei8V64VoidVBSF64VUVF_m, soxei8_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 4, OneDBool, ScalarFloat64, OneDUInt8, OneDFloat64)
+CUSTOM_OP_TYPE(Soxei16V64VoidVBSF64VUVF_m, soxei16_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 4, OneDBool, ScalarFloat64, OneDUInt16, OneDFloat64)
+CUSTOM_OP_TYPE(Soxei32V64VoidVBSF64VUVF_m, soxei32_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 4, OneDBool, ScalarFloat64, OneDUInt32, OneDFloat64)
+CUSTOM_OP_TYPE(Soxei64V64VoidVBSF64VUVF_m, soxei64_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 4, OneDBool, ScalarFloat64, OneDUInt64, OneDFloat64)
+CUSTOM_OP_TYPE(Suxei8V16VoidVBSF16VUVF_m, suxei8_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 4, OneDBool, ScalarFloat16, OneDUInt8, OneDFloat16)
+CUSTOM_OP_TYPE(Suxei16V16VoidVBSF16VUVF_m, suxei16_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 4, OneDBool, ScalarFloat16, OneDUInt16, OneDFloat16)
+CUSTOM_OP_TYPE(Suxei32V16VoidVBSF16VUVF_m, suxei32_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 4, OneDBool, ScalarFloat16, OneDUInt32, OneDFloat16)
+CUSTOM_OP_TYPE(Suxei64V16VoidVBSF16VUVF_m, suxei64_v, 16, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat16, 4, OneDBool, ScalarFloat16, OneDUInt64, OneDFloat16)
+CUSTOM_OP_TYPE(Suxei8V32VoidVBSF32VUVF_m, suxei8_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 4, OneDBool, ScalarFloat32, OneDUInt8, OneDFloat32)
+CUSTOM_OP_TYPE(Suxei16V32VoidVBSF32VUVF_m, suxei16_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 4, OneDBool, ScalarFloat32, OneDUInt16, OneDFloat32)
+CUSTOM_OP_TYPE(Suxei32V32VoidVBSF32VUVF_m, suxei32_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 4, OneDBool, ScalarFloat32, OneDUInt32, OneDFloat32)
+CUSTOM_OP_TYPE(Suxei64V32VoidVBSF32VUVF_m, suxei64_v, 32, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat32, 4, OneDBool, ScalarFloat32, OneDUInt64, OneDFloat32)
+CUSTOM_OP_TYPE(Suxei8V64VoidVBSF64VUVF_m, suxei8_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 4, OneDBool, ScalarFloat64, OneDUInt8, OneDFloat64)
+CUSTOM_OP_TYPE(Suxei16V64VoidVBSF64VUVF_m, suxei16_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 4, OneDBool, ScalarFloat64, OneDUInt16, OneDFloat64)
+CUSTOM_OP_TYPE(Suxei32V64VoidVBSF64VUVF_m, suxei32_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 4, OneDBool, ScalarFloat64, OneDUInt32, OneDFloat64)
+CUSTOM_OP_TYPE(Suxei64V64VoidVBSF64VUVF_m, suxei64_v, 64, FLOAT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDFloat64, 4, OneDBool, ScalarFloat64, OneDUInt64, OneDFloat64)
+CUSTOM_OP_TYPE(Soxei8V8VoidVBSIVUVI_m, soxei8_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 4, OneDBool, ScalarInt8, OneDUInt8, OneDInt8)
+CUSTOM_OP_TYPE(Soxei16V8VoidVBSIVUVI_m, soxei16_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 4, OneDBool, ScalarInt8, OneDUInt16, OneDInt8)
+CUSTOM_OP_TYPE(Soxei32V8VoidVBSIVUVI_m, soxei32_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 4, OneDBool, ScalarInt8, OneDUInt32, OneDInt8)
+CUSTOM_OP_TYPE(Soxei64V8VoidVBSIVUVI_m, soxei64_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 4, OneDBool, ScalarInt8, OneDUInt64, OneDInt8)
+CUSTOM_OP_TYPE(Soxei8V16VoidVBSIVUVI_m, soxei8_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 4, OneDBool, ScalarInt16, OneDUInt8, OneDInt16)
+CUSTOM_OP_TYPE(Soxei16V16VoidVBSIVUVI_m, soxei16_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 4, OneDBool, ScalarInt16, OneDUInt16, OneDInt16)
+CUSTOM_OP_TYPE(Soxei32V16VoidVBSIVUVI_m, soxei32_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 4, OneDBool, ScalarInt16, OneDUInt32, OneDInt16)
+CUSTOM_OP_TYPE(Soxei64V16VoidVBSIVUVI_m, soxei64_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 4, OneDBool, ScalarInt16, OneDUInt64, OneDInt16)
+CUSTOM_OP_TYPE(Soxei8V32VoidVBSIVUVI_m, soxei8_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 4, OneDBool, ScalarInt32, OneDUInt8, OneDInt32)
+CUSTOM_OP_TYPE(Soxei16V32VoidVBSIVUVI_m, soxei16_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 4, OneDBool, ScalarInt32, OneDUInt16, OneDInt32)
+CUSTOM_OP_TYPE(Soxei32V32VoidVBSIVUVI_m, soxei32_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 4, OneDBool, ScalarInt32, OneDUInt32, OneDInt32)
+CUSTOM_OP_TYPE(Soxei64V32VoidVBSIVUVI_m, soxei64_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 4, OneDBool, ScalarInt32, OneDUInt64, OneDInt32)
+CUSTOM_OP_TYPE(Soxei8V64VoidVBSIVUVI_m, soxei8_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 4, OneDBool, ScalarInt64, OneDUInt8, OneDInt64)
+CUSTOM_OP_TYPE(Soxei16V64VoidVBSIVUVI_m, soxei16_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 4, OneDBool, ScalarInt64, OneDUInt16, OneDInt64)
+CUSTOM_OP_TYPE(Soxei32V64VoidVBSIVUVI_m, soxei32_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 4, OneDBool, ScalarInt64, OneDUInt32, OneDInt64)
+CUSTOM_OP_TYPE(Soxei64V64VoidVBSIVUVI_m, soxei64_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 4, OneDBool, ScalarInt64, OneDUInt64, OneDInt64)
+CUSTOM_OP_TYPE(Suxei8V8VoidVBSIVUVI_m, suxei8_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 4, OneDBool, ScalarInt8, OneDUInt8, OneDInt8)
+CUSTOM_OP_TYPE(Suxei16V8VoidVBSIVUVI_m, suxei16_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 4, OneDBool, ScalarInt8, OneDUInt16, OneDInt8)
+CUSTOM_OP_TYPE(Suxei32V8VoidVBSIVUVI_m, suxei32_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 4, OneDBool, ScalarInt8, OneDUInt32, OneDInt8)
+CUSTOM_OP_TYPE(Suxei64V8VoidVBSIVUVI_m, suxei64_v, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt8, 4, OneDBool, ScalarInt8, OneDUInt64, OneDInt8)
+CUSTOM_OP_TYPE(Suxei8V16VoidVBSIVUVI_m, suxei8_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 4, OneDBool, ScalarInt16, OneDUInt8, OneDInt16)
+CUSTOM_OP_TYPE(Suxei16V16VoidVBSIVUVI_m, suxei16_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 4, OneDBool, ScalarInt16, OneDUInt16, OneDInt16)
+CUSTOM_OP_TYPE(Suxei32V16VoidVBSIVUVI_m, suxei32_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 4, OneDBool, ScalarInt16, OneDUInt32, OneDInt16)
+CUSTOM_OP_TYPE(Suxei64V16VoidVBSIVUVI_m, suxei64_v, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt16, 4, OneDBool, ScalarInt16, OneDUInt64, OneDInt16)
+CUSTOM_OP_TYPE(Suxei8V32VoidVBSIVUVI_m, suxei8_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 4, OneDBool, ScalarInt32, OneDUInt8, OneDInt32)
+CUSTOM_OP_TYPE(Suxei16V32VoidVBSIVUVI_m, suxei16_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 4, OneDBool, ScalarInt32, OneDUInt16, OneDInt32)
+CUSTOM_OP_TYPE(Suxei32V32VoidVBSIVUVI_m, suxei32_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 4, OneDBool, ScalarInt32, OneDUInt32, OneDInt32)
+CUSTOM_OP_TYPE(Suxei64V32VoidVBSIVUVI_m, suxei64_v, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt32, 4, OneDBool, ScalarInt32, OneDUInt64, OneDInt32)
+CUSTOM_OP_TYPE(Suxei8V64VoidVBSIVUVI_m, suxei8_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 4, OneDBool, ScalarInt64, OneDUInt8, OneDInt64)
+CUSTOM_OP_TYPE(Suxei16V64VoidVBSIVUVI_m, suxei16_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 4, OneDBool, ScalarInt64, OneDUInt16, OneDInt64)
+CUSTOM_OP_TYPE(Suxei32V64VoidVBSIVUVI_m, suxei32_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 4, OneDBool, ScalarInt64, OneDUInt32, OneDInt64)
+CUSTOM_OP_TYPE(Suxei64V64VoidVBSIVUVI_m, suxei64_v, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDInt64, 4, OneDBool, ScalarInt64, OneDUInt64, OneDInt64)
+CUSTOM_OP_TYPE(Soxei8V8VoidVBSUVUVU_m, soxei8_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 4, OneDBool, ScalarUInt8, OneDUInt8, OneDUInt8)
+CUSTOM_OP_TYPE(Soxei16V8VoidVBSUVUVU_m, soxei16_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 4, OneDBool, ScalarUInt8, OneDUInt16, OneDUInt8)
+CUSTOM_OP_TYPE(Soxei32V8VoidVBSUVUVU_m, soxei32_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 4, OneDBool, ScalarUInt8, OneDUInt32, OneDUInt8)
+CUSTOM_OP_TYPE(Soxei64V8VoidVBSUVUVU_m, soxei64_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 4, OneDBool, ScalarUInt8, OneDUInt64, OneDUInt8)
+CUSTOM_OP_TYPE(Soxei8V16VoidVBSUVUVU_m, soxei8_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 4, OneDBool, ScalarUInt16, OneDUInt8, OneDUInt16)
+CUSTOM_OP_TYPE(Soxei16V16VoidVBSUVUVU_m, soxei16_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 4, OneDBool, ScalarUInt16, OneDUInt16, OneDUInt16)
+CUSTOM_OP_TYPE(Soxei32V16VoidVBSUVUVU_m, soxei32_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 4, OneDBool, ScalarUInt16, OneDUInt32, OneDUInt16)
+CUSTOM_OP_TYPE(Soxei64V16VoidVBSUVUVU_m, soxei64_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 4, OneDBool, ScalarUInt16, OneDUInt64, OneDUInt16)
+CUSTOM_OP_TYPE(Soxei8V32VoidVBSUVUVU_m, soxei8_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 4, OneDBool, ScalarUInt32, OneDUInt8, OneDUInt32)
+CUSTOM_OP_TYPE(Soxei16V32VoidVBSUVUVU_m, soxei16_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 4, OneDBool, ScalarUInt32, OneDUInt16, OneDUInt32)
+CUSTOM_OP_TYPE(Soxei32V32VoidVBSUVUVU_m, soxei32_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 4, OneDBool, ScalarUInt32, OneDUInt32, OneDUInt32)
+CUSTOM_OP_TYPE(Soxei64V32VoidVBSUVUVU_m, soxei64_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 4, OneDBool, ScalarUInt32, OneDUInt64, OneDUInt32)
+CUSTOM_OP_TYPE(Soxei8V64VoidVBSUVUVU_m, soxei8_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 4, OneDBool, ScalarUInt64, OneDUInt8, OneDUInt64)
+CUSTOM_OP_TYPE(Soxei16V64VoidVBSUVUVU_m, soxei16_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 4, OneDBool, ScalarUInt64, OneDUInt16, OneDUInt64)
+CUSTOM_OP_TYPE(Soxei32V64VoidVBSUVUVU_m, soxei32_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 4, OneDBool, ScalarUInt64, OneDUInt32, OneDUInt64)
+CUSTOM_OP_TYPE(Soxei64V64VoidVBSUVUVU_m, soxei64_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 4, OneDBool, ScalarUInt64, OneDUInt64, OneDUInt64)
+CUSTOM_OP_TYPE(Suxei8V8VoidVBSUVUVU_m, suxei8_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 4, OneDBool, ScalarUInt8, OneDUInt8, OneDUInt8)
+CUSTOM_OP_TYPE(Suxei16V8VoidVBSUVUVU_m, suxei16_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 4, OneDBool, ScalarUInt8, OneDUInt16, OneDUInt8)
+CUSTOM_OP_TYPE(Suxei32V8VoidVBSUVUVU_m, suxei32_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 4, OneDBool, ScalarUInt8, OneDUInt32, OneDUInt8)
+CUSTOM_OP_TYPE(Suxei64V8VoidVBSUVUVU_m, suxei64_v, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt8, 4, OneDBool, ScalarUInt8, OneDUInt64, OneDUInt8)
+CUSTOM_OP_TYPE(Suxei8V16VoidVBSUVUVU_m, suxei8_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 4, OneDBool, ScalarUInt16, OneDUInt8, OneDUInt16)
+CUSTOM_OP_TYPE(Suxei16V16VoidVBSUVUVU_m, suxei16_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 4, OneDBool, ScalarUInt16, OneDUInt16, OneDUInt16)
+CUSTOM_OP_TYPE(Suxei32V16VoidVBSUVUVU_m, suxei32_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 4, OneDBool, ScalarUInt16, OneDUInt32, OneDUInt16)
+CUSTOM_OP_TYPE(Suxei64V16VoidVBSUVUVU_m, suxei64_v, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt16, 4, OneDBool, ScalarUInt16, OneDUInt64, OneDUInt16)
+CUSTOM_OP_TYPE(Suxei8V32VoidVBSUVUVU_m, suxei8_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 4, OneDBool, ScalarUInt32, OneDUInt8, OneDUInt32)
+CUSTOM_OP_TYPE(Suxei16V32VoidVBSUVUVU_m, suxei16_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 4, OneDBool, ScalarUInt32, OneDUInt16, OneDUInt32)
+CUSTOM_OP_TYPE(Suxei32V32VoidVBSUVUVU_m, suxei32_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 4, OneDBool, ScalarUInt32, OneDUInt32, OneDUInt32)
+CUSTOM_OP_TYPE(Suxei64V32VoidVBSUVUVU_m, suxei64_v, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt32, 4, OneDBool, ScalarUInt32, OneDUInt64, OneDUInt32)
+CUSTOM_OP_TYPE(Suxei8V64VoidVBSUVUVU_m, suxei8_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 4, OneDBool, ScalarUInt64, OneDUInt8, OneDUInt64)
+CUSTOM_OP_TYPE(Suxei16V64VoidVBSUVUVU_m, suxei16_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 4, OneDBool, ScalarUInt64, OneDUInt16, OneDUInt64)
+CUSTOM_OP_TYPE(Suxei32V64VoidVBSUVUVU_m, suxei32_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 4, OneDBool, ScalarUInt64, OneDUInt32, OneDUInt64)
+CUSTOM_OP_TYPE(Suxei64V64VoidVBSUVUVU_m, suxei64_v, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | VoidOperation | StoreOperation, OneDUInt64, 4, OneDBool, ScalarUInt64, OneDUInt64, OneDUInt64)
+CUSTOM_OP_TYPE(Le16ffX16VFloat16SF16SZP, le16ff_x, 16, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat16, 2, ScalarFloat16, SizePtr)
+CUSTOM_OP_TYPE(Le32ffX32VFloat32SF32SZP, le32ff_x, 32, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat32, 2, ScalarFloat32, SizePtr)
+CUSTOM_OP_TYPE(Le64ffX64VFloat64SF64SZP, le64ff_x, 64, FLOAT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDFloat64, 2, ScalarFloat64, SizePtr)
+CUSTOM_OP_TYPE(Le8ffX8VInt8SISZP, le8ff_x, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt8, 2, ScalarInt8, SizePtr)
+CUSTOM_OP_TYPE(Le16ffX16VInt16SISZP, le16ff_x, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt16, 2, ScalarInt16, SizePtr)
+CUSTOM_OP_TYPE(Le32ffX32VInt32SISZP, le32ff_x, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt32, 2, ScalarInt32, SizePtr)
+CUSTOM_OP_TYPE(Le64ffX64VInt64SISZP, le64ff_x, 64, SIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDInt64, 2, ScalarInt64, SizePtr)
+CUSTOM_OP_TYPE(Le8ffX8VUInt8SUSZP, le8ff_x, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt8, 2, ScalarUInt8, SizePtr)
+CUSTOM_OP_TYPE(Le16ffX16VUInt16SUSZP, le16ff_x, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt16, 2, ScalarUInt16, SizePtr)
+CUSTOM_OP_TYPE(Le32ffX32VUInt32SUSZP, le32ff_x, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt32, 2, ScalarUInt32, SizePtr)
+CUSTOM_OP_TYPE(Le64ffX64VUInt64SUSZP, le64ff_x, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation | LoadOperation, OneDUInt64, 2, ScalarUInt64, SizePtr)
+CUSTOM_OP_TYPE(Le16ffX16VFloat16VBSF16SZP_m, le16ff_x, 16, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat16, 3, OneDBool, ScalarFloat16, SizePtr)
+CUSTOM_OP_TYPE(Le32ffX32VFloat32VBSF32SZP_m, le32ff_x, 32, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat32, 3, OneDBool, ScalarFloat32, SizePtr)
+CUSTOM_OP_TYPE(Le64ffX64VFloat64VBSF64SZP_m, le64ff_x, 64, FLOAT, HaveVLParameter | MaskedOperation | LoadOperation, OneDFloat64, 3, OneDBool, ScalarFloat64, SizePtr)
+CUSTOM_OP_TYPE(Le8ffX8VInt8VBSISZP_m, le8ff_x, 8, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt8, 3, OneDBool, ScalarInt8, SizePtr)
+CUSTOM_OP_TYPE(Le16ffX16VInt16VBSISZP_m, le16ff_x, 16, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt16, 3, OneDBool, ScalarInt16, SizePtr)
+CUSTOM_OP_TYPE(Le32ffX32VInt32VBSISZP_m, le32ff_x, 32, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt32, 3, OneDBool, ScalarInt32, SizePtr)
+CUSTOM_OP_TYPE(Le64ffX64VInt64VBSISZP_m, le64ff_x, 64, SIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDInt64, 3, OneDBool, ScalarInt64, SizePtr)
+CUSTOM_OP_TYPE(Le8ffX8VUInt8VBSUSZP_m, le8ff_x, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt8, 3, OneDBool, ScalarUInt8, SizePtr)
+CUSTOM_OP_TYPE(Le16ffX16VUInt16VBSUSZP_m, le16ff_x, 16, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt16, 3, OneDBool, ScalarUInt16, SizePtr)
+CUSTOM_OP_TYPE(Le32ffX32VUInt32VBSUSZP_m, le32ff_x, 32, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt32, 3, OneDBool, ScalarUInt32, SizePtr)
+CUSTOM_OP_TYPE(Le64ffX64VUInt64VBSUSZP_m, le64ff_x, 64, UNSIGNED_INT, HaveVLParameter | MaskedOperation | LoadOperation, OneDUInt64, 3, OneDBool, ScalarUInt64, SizePtr)
 CUSTOM_OP_TYPE(AddVV8VInt8VIVI, add_vv, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDInt8, 2, OneDInt8, OneDInt8)
 CUSTOM_OP_TYPE(AddVX8VInt8VISI, add_vx, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDInt8, 2, OneDInt8, ScalarInt8)
 CUSTOM_OP_TYPE(AddVV16VInt16VIVI, add_vv, 16, SIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDInt16, 2, OneDInt16, OneDInt16)
@@ -3362,162 +3362,332 @@ CUSTOM_OP_TYPE(CreateCREATE32VUInt32VUVUVUVUVUVUVUVU, create_create, 32, UNSIGNE
 CUSTOM_OP_TYPE(CreateCREATE64VUInt64VUVU, create_create, 64, UNSIGNED_INT, NoVLParameter | NonmaskedOperation, OneDUInt64, 2, OneDUInt64, OneDUInt64)
 CUSTOM_OP_TYPE(CreateCREATE64VUInt64VUVUVUVU, create_create, 64, UNSIGNED_INT, NoVLParameter | NonmaskedOperation, OneDUInt64, 4, OneDUInt64, OneDUInt64, OneDUInt64, OneDUInt64)
 CUSTOM_OP_TYPE(CreateCREATE64VUInt64VUVUVUVUVUVUVUVU, create_create, 64, UNSIGNED_INT, NoVLParameter | NonmaskedOperation, OneDUInt64, 8, OneDUInt64, OneDUInt64, OneDUInt64, OneDUInt64, OneDUInt64, OneDUInt64, OneDUInt64, OneDUInt64)
-CUSTOM_OP_TYPE(F_vqmacc_4x8x4VV32VInt32VIVIVI, f_vqmacc_4x8x4_vv, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDInt32, 3, OneDInt32, OneDInt8, OneDInt8)
-CUSTOM_OP_TYPE(F_vqmaccus_4x8x4VV32VInt32VIVUVI, f_vqmaccus_4x8x4_vv, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDInt32, 3, OneDInt32, OneDUInt8, OneDInt8)
-CUSTOM_OP_TYPE(F_vqmaccsu_4x8x4VV32VInt32VIVIVU, f_vqmaccsu_4x8x4_vv, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDInt32, 3, OneDInt32, OneDInt8, OneDUInt8)
-CUSTOM_OP_TYPE(F_vqmaccu_4x8x4VV32VInt32VIVUVU, f_vqmaccu_4x8x4_vv, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDInt32, 3, OneDInt32, OneDUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(F_vqmacc_2x8x2VV32VInt32VIVIVI, f_vqmacc_2x8x2_vv, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDInt32, 3, OneDInt32, OneDInt8, OneDInt8)
-CUSTOM_OP_TYPE(F_vqmaccus_2x8x2VV32VInt32VIVUVI, f_vqmaccus_2x8x2_vv, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDInt32, 3, OneDInt32, OneDUInt8, OneDInt8)
-CUSTOM_OP_TYPE(F_vqmaccsu_2x8x2VV32VInt32VIVIVU, f_vqmaccsu_2x8x2_vv, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDInt32, 3, OneDInt32, OneDInt8, OneDUInt8)
-CUSTOM_OP_TYPE(F_vqmaccu_2x8x2VV32VInt32VIVUVU, f_vqmaccu_2x8x2_vv, 32, SIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDInt32, 3, OneDInt32, OneDUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(F_vfnrclip_x_f_qfVF8VInt8VFSF32, f_vfnrclip_x_f_qf_vf, 8, SIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDInt8, 2, OneDFloat32, ScalarFloat32)
-CUSTOM_OP_TYPE(F_vfnrclip_xu_f_qfVF8VUInt8VFSF32, f_vfnrclip_xu_f_qf_vf, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt8, 2, OneDFloat32, ScalarFloat32)
-CUSTOM_OP_TYPE(F_vfnrclip_x_f_qfVF8VInt8VBVFSF32_m, f_vfnrclip_x_f_qf_vf, 8, SIGNED_INT, HaveVLParameter | MaskedOperation, OneDInt8, 3, OneDBool, OneDFloat32, ScalarFloat32)
-CUSTOM_OP_TYPE(F_vfnrclip_xu_f_qfVF8VUInt8VBVFSF32_m, f_vfnrclip_xu_f_qf_vf, 8, UNSIGNED_INT, HaveVLParameter | MaskedOperation, OneDUInt8, 3, OneDBool, OneDFloat32, ScalarFloat32)
-CUSTOM_OP_TYPE(F_vc_x8VoidSISISISU, f_vc_x_, 8, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen, ScalarUInt8)
-CUSTOM_OP_TYPE(F_vc_x16VoidSISISISU, f_vc_x_, 16, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen, ScalarUInt16)
-CUSTOM_OP_TYPE(F_vc_x32VoidSISISISU, f_vc_x_, 32, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen, ScalarUInt32)
-CUSTOM_OP_TYPE(F_vc_x64VoidSISISISU, f_vc_x_, 64, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen, ScalarUInt64)
-CUSTOM_OP_TYPE(F_vc_v_xX8VUInt8SISISU, f_vc_v_x_x, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt8, 3, ScalarIntXLen, ScalarIntXLen, ScalarUInt8)
-CUSTOM_OP_TYPE(F_vc_v_xX8VUInt8SISISU, f_vc_v_x_x, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt8, 3, ScalarIntXLen, ScalarIntXLen, ScalarUInt8)
-CUSTOM_OP_TYPE(F_vc_v_xX16VUInt16SISISU, f_vc_v_x_x, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 3, ScalarIntXLen, ScalarIntXLen, ScalarUInt16)
-CUSTOM_OP_TYPE(F_vc_v_xX16VUInt16SISISU, f_vc_v_x_x, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 3, ScalarIntXLen, ScalarIntXLen, ScalarUInt16)
-CUSTOM_OP_TYPE(F_vc_v_xX32VUInt32SISISU, f_vc_v_x_x, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 3, ScalarIntXLen, ScalarIntXLen, ScalarUInt32)
-CUSTOM_OP_TYPE(F_vc_v_xX32VUInt32SISISU, f_vc_v_x_x, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 3, ScalarIntXLen, ScalarIntXLen, ScalarUInt32)
-CUSTOM_OP_TYPE(F_vc_v_xX64VUInt64SISISU, f_vc_v_x_x, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 3, ScalarIntXLen, ScalarIntXLen, ScalarUInt64)
-CUSTOM_OP_TYPE(F_vc_v_xX64VUInt64SISISU, f_vc_v_x_x, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 3, ScalarIntXLen, ScalarIntXLen, ScalarUInt64)
-CUSTOM_OP_TYPE(F_vc_i8VoidSISISISI, f_vc_i_, 8, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_i16VoidSISISISI, f_vc_i_, 16, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_i32VoidSISISISI, f_vc_i_, 32, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_i64VoidSISISISI, f_vc_i_, 64, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_iI8VUInt8SISISI, f_vc_v_i_i, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt8, 3, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_iI8VUInt8SISISI, f_vc_v_i_i, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt8, 3, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_iI16VUInt16SISISI, f_vc_v_i_i, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 3, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_iI16VUInt16SISISI, f_vc_v_i_i, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 3, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_iI32VUInt32SISISI, f_vc_v_i_i, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 3, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_iI32VUInt32SISISI, f_vc_v_i_i, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 3, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_iI64VUInt64SISISI, f_vc_v_i_i, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 3, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_iI64VUInt64SISISI, f_vc_v_i_i, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 3, ScalarIntXLen, ScalarIntXLen, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_vvV8VoidSISIVUVU, f_vc_vv_v, 8, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, OneDUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(F_vc_vvV16VoidSISIVUVU, f_vc_vv_v, 16, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, OneDUInt16, OneDUInt16)
-CUSTOM_OP_TYPE(F_vc_vvV32VoidSISIVUVU, f_vc_vv_v, 32, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, OneDUInt32, OneDUInt32)
-CUSTOM_OP_TYPE(F_vc_vvV64VoidSISIVUVU, f_vc_vv_v, 64, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, OneDUInt64, OneDUInt64)
-CUSTOM_OP_TYPE(F_vc_v_vvVV8VUInt8SIVUVU, f_vc_v_vv_vv, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt8, 3, ScalarIntXLen, OneDUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(F_vc_v_vvVV8VUInt8SIVUVU, f_vc_v_vv_vv, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt8, 3, ScalarIntXLen, OneDUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(F_vc_v_vvVV16VUInt16SIVUVU, f_vc_v_vv_vv, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 3, ScalarIntXLen, OneDUInt16, OneDUInt16)
-CUSTOM_OP_TYPE(F_vc_v_vvVV16VUInt16SIVUVU, f_vc_v_vv_vv, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 3, ScalarIntXLen, OneDUInt16, OneDUInt16)
-CUSTOM_OP_TYPE(F_vc_v_vvVV32VUInt32SIVUVU, f_vc_v_vv_vv, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 3, ScalarIntXLen, OneDUInt32, OneDUInt32)
-CUSTOM_OP_TYPE(F_vc_v_vvVV32VUInt32SIVUVU, f_vc_v_vv_vv, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 3, ScalarIntXLen, OneDUInt32, OneDUInt32)
-CUSTOM_OP_TYPE(F_vc_v_vvVV64VUInt64SIVUVU, f_vc_v_vv_vv, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 3, ScalarIntXLen, OneDUInt64, OneDUInt64)
-CUSTOM_OP_TYPE(F_vc_v_vvVV64VUInt64SIVUVU, f_vc_v_vv_vv, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 3, ScalarIntXLen, OneDUInt64, OneDUInt64)
-CUSTOM_OP_TYPE(F_vc_xvX8VoidSISIVUSU, f_vc_xv_x, 8, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, OneDUInt8, ScalarUInt8)
-CUSTOM_OP_TYPE(F_vc_xvX16VoidSISIVUSU, f_vc_xv_x, 16, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, OneDUInt16, ScalarUInt16)
-CUSTOM_OP_TYPE(F_vc_xvX32VoidSISIVUSU, f_vc_xv_x, 32, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, OneDUInt32, ScalarUInt32)
-CUSTOM_OP_TYPE(F_vc_xvX64VoidSISIVUSU, f_vc_xv_x, 64, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, OneDUInt64, ScalarUInt64)
-CUSTOM_OP_TYPE(F_vc_v_xvVX8VUInt8SIVUSU, f_vc_v_xv_vx, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt8, 3, ScalarIntXLen, OneDUInt8, ScalarUInt8)
-CUSTOM_OP_TYPE(F_vc_v_xvVX8VUInt8SIVUSU, f_vc_v_xv_vx, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt8, 3, ScalarIntXLen, OneDUInt8, ScalarUInt8)
-CUSTOM_OP_TYPE(F_vc_v_xvVX16VUInt16SIVUSU, f_vc_v_xv_vx, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 3, ScalarIntXLen, OneDUInt16, ScalarUInt16)
-CUSTOM_OP_TYPE(F_vc_v_xvVX16VUInt16SIVUSU, f_vc_v_xv_vx, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 3, ScalarIntXLen, OneDUInt16, ScalarUInt16)
-CUSTOM_OP_TYPE(F_vc_v_xvVX32VUInt32SIVUSU, f_vc_v_xv_vx, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 3, ScalarIntXLen, OneDUInt32, ScalarUInt32)
-CUSTOM_OP_TYPE(F_vc_v_xvVX32VUInt32SIVUSU, f_vc_v_xv_vx, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 3, ScalarIntXLen, OneDUInt32, ScalarUInt32)
-CUSTOM_OP_TYPE(F_vc_v_xvVX64VUInt64SIVUSU, f_vc_v_xv_vx, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 3, ScalarIntXLen, OneDUInt64, ScalarUInt64)
-CUSTOM_OP_TYPE(F_vc_v_xvVX64VUInt64SIVUSU, f_vc_v_xv_vx, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 3, ScalarIntXLen, OneDUInt64, ScalarUInt64)
-CUSTOM_OP_TYPE(F_vc_ivI8VoidSISIVUSI, f_vc_iv_i, 8, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, OneDUInt8, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_ivI16VoidSISIVUSI, f_vc_iv_i, 16, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, OneDUInt16, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_ivI32VoidSISIVUSI, f_vc_iv_i, 32, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, OneDUInt32, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_ivI64VoidSISIVUSI, f_vc_iv_i, 64, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, OneDUInt64, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivVI8VUInt8SIVUSI, f_vc_v_iv_vi, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt8, 3, ScalarIntXLen, OneDUInt8, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivVI8VUInt8SIVUSI, f_vc_v_iv_vi, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt8, 3, ScalarIntXLen, OneDUInt8, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivVI16VUInt16SIVUSI, f_vc_v_iv_vi, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 3, ScalarIntXLen, OneDUInt16, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivVI16VUInt16SIVUSI, f_vc_v_iv_vi, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 3, ScalarIntXLen, OneDUInt16, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivVI32VUInt32SIVUSI, f_vc_v_iv_vi, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 3, ScalarIntXLen, OneDUInt32, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivVI32VUInt32SIVUSI, f_vc_v_iv_vi, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 3, ScalarIntXLen, OneDUInt32, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivVI64VUInt64SIVUSI, f_vc_v_iv_vi, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 3, ScalarIntXLen, OneDUInt64, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivVI64VUInt64SIVUSI, f_vc_v_iv_vi, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 3, ScalarIntXLen, OneDUInt64, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_fvF16VoidSISIVUSF, f_vc_fv_f, 16, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, OneDUInt16, ScalarFloat16)
-CUSTOM_OP_TYPE(F_vc_fvF32VoidSISIVUSF, f_vc_fv_f, 32, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, OneDUInt32, ScalarFloat32)
-CUSTOM_OP_TYPE(F_vc_fvF64VoidSISIVUSF, f_vc_fv_f, 64, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, ScalarIntXLen, OneDUInt64, ScalarFloat64)
-CUSTOM_OP_TYPE(F_vc_v_fvVF16VUInt16SIVUSF, f_vc_v_fv_vf, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 3, ScalarIntXLen, OneDUInt16, ScalarFloat16)
-CUSTOM_OP_TYPE(F_vc_v_fvVF16VUInt16SIVUSF, f_vc_v_fv_vf, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 3, ScalarIntXLen, OneDUInt16, ScalarFloat16)
-CUSTOM_OP_TYPE(F_vc_v_fvVF32VUInt32SIVUSF, f_vc_v_fv_vf, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 3, ScalarIntXLen, OneDUInt32, ScalarFloat32)
-CUSTOM_OP_TYPE(F_vc_v_fvVF32VUInt32SIVUSF, f_vc_v_fv_vf, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 3, ScalarIntXLen, OneDUInt32, ScalarFloat32)
-CUSTOM_OP_TYPE(F_vc_v_fvVF64VUInt64SIVUSF, f_vc_v_fv_vf, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 3, ScalarIntXLen, OneDUInt64, ScalarFloat64)
-CUSTOM_OP_TYPE(F_vc_v_fvVF64VUInt64SIVUSF, f_vc_v_fv_vf, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 3, ScalarIntXLen, OneDUInt64, ScalarFloat64)
-CUSTOM_OP_TYPE(F_vc_vvvVV8VoidSIVUVUVU, f_vc_vvv_vv, 8, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt8, OneDUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(F_vc_vvvVV16VoidSIVUVUVU, f_vc_vvv_vv, 16, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt16, OneDUInt16, OneDUInt16)
-CUSTOM_OP_TYPE(F_vc_vvvVV32VoidSIVUVUVU, f_vc_vvv_vv, 32, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt32, OneDUInt32, OneDUInt32)
-CUSTOM_OP_TYPE(F_vc_vvvVV64VoidSIVUVUVU, f_vc_vvv_vv, 64, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt64, OneDUInt64, OneDUInt64)
-CUSTOM_OP_TYPE(F_vc_v_vvvVV8VUInt8SIVUVUVU, f_vc_v_vvv_vv, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt8, 4, ScalarIntXLen, OneDUInt8, OneDUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(F_vc_v_vvvVV8VUInt8SIVUVUVU, f_vc_v_vvv_vv, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt8, 4, ScalarIntXLen, OneDUInt8, OneDUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(F_vc_v_vvvVV16VUInt16SIVUVUVU, f_vc_v_vvv_vv, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 4, ScalarIntXLen, OneDUInt16, OneDUInt16, OneDUInt16)
-CUSTOM_OP_TYPE(F_vc_v_vvvVV16VUInt16SIVUVUVU, f_vc_v_vvv_vv, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 4, ScalarIntXLen, OneDUInt16, OneDUInt16, OneDUInt16)
-CUSTOM_OP_TYPE(F_vc_v_vvvVV32VUInt32SIVUVUVU, f_vc_v_vvv_vv, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 4, ScalarIntXLen, OneDUInt32, OneDUInt32, OneDUInt32)
-CUSTOM_OP_TYPE(F_vc_v_vvvVV32VUInt32SIVUVUVU, f_vc_v_vvv_vv, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 4, ScalarIntXLen, OneDUInt32, OneDUInt32, OneDUInt32)
-CUSTOM_OP_TYPE(F_vc_v_vvvVV64VUInt64SIVUVUVU, f_vc_v_vvv_vv, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 4, ScalarIntXLen, OneDUInt64, OneDUInt64, OneDUInt64)
-CUSTOM_OP_TYPE(F_vc_v_vvvVV64VUInt64SIVUVUVU, f_vc_v_vvv_vv, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 4, ScalarIntXLen, OneDUInt64, OneDUInt64, OneDUInt64)
-CUSTOM_OP_TYPE(F_vc_xvvVX8VoidSIVUVUSU, f_vc_xvv_vx, 8, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt8, OneDUInt8, ScalarUInt8)
-CUSTOM_OP_TYPE(F_vc_xvvVX16VoidSIVUVUSU, f_vc_xvv_vx, 16, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt16, OneDUInt16, ScalarUInt16)
-CUSTOM_OP_TYPE(F_vc_xvvVX32VoidSIVUVUSU, f_vc_xvv_vx, 32, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt32, OneDUInt32, ScalarUInt32)
-CUSTOM_OP_TYPE(F_vc_xvvVX64VoidSIVUVUSU, f_vc_xvv_vx, 64, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt64, OneDUInt64, ScalarUInt64)
-CUSTOM_OP_TYPE(F_vc_v_xvvVX8VUInt8SIVUVUSU, f_vc_v_xvv_vx, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt8, 4, ScalarIntXLen, OneDUInt8, OneDUInt8, ScalarUInt8)
-CUSTOM_OP_TYPE(F_vc_v_xvvVX8VUInt8SIVUVUSU, f_vc_v_xvv_vx, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt8, 4, ScalarIntXLen, OneDUInt8, OneDUInt8, ScalarUInt8)
-CUSTOM_OP_TYPE(F_vc_v_xvvVX16VUInt16SIVUVUSU, f_vc_v_xvv_vx, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 4, ScalarIntXLen, OneDUInt16, OneDUInt16, ScalarUInt16)
-CUSTOM_OP_TYPE(F_vc_v_xvvVX16VUInt16SIVUVUSU, f_vc_v_xvv_vx, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 4, ScalarIntXLen, OneDUInt16, OneDUInt16, ScalarUInt16)
-CUSTOM_OP_TYPE(F_vc_v_xvvVX32VUInt32SIVUVUSU, f_vc_v_xvv_vx, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 4, ScalarIntXLen, OneDUInt32, OneDUInt32, ScalarUInt32)
-CUSTOM_OP_TYPE(F_vc_v_xvvVX32VUInt32SIVUVUSU, f_vc_v_xvv_vx, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 4, ScalarIntXLen, OneDUInt32, OneDUInt32, ScalarUInt32)
-CUSTOM_OP_TYPE(F_vc_v_xvvVX64VUInt64SIVUVUSU, f_vc_v_xvv_vx, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 4, ScalarIntXLen, OneDUInt64, OneDUInt64, ScalarUInt64)
-CUSTOM_OP_TYPE(F_vc_v_xvvVX64VUInt64SIVUVUSU, f_vc_v_xvv_vx, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 4, ScalarIntXLen, OneDUInt64, OneDUInt64, ScalarUInt64)
-CUSTOM_OP_TYPE(F_vc_ivvVI8VoidSIVUVUSI, f_vc_ivv_vi, 8, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt8, OneDUInt8, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_ivvVI16VoidSIVUVUSI, f_vc_ivv_vi, 16, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt16, OneDUInt16, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_ivvVI32VoidSIVUVUSI, f_vc_ivv_vi, 32, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt32, OneDUInt32, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_ivvVI64VoidSIVUVUSI, f_vc_ivv_vi, 64, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt64, OneDUInt64, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivvVI8VUInt8SIVUVUSI, f_vc_v_ivv_vi, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt8, 4, ScalarIntXLen, OneDUInt8, OneDUInt8, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivvVI8VUInt8SIVUVUSI, f_vc_v_ivv_vi, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt8, 4, ScalarIntXLen, OneDUInt8, OneDUInt8, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivvVI16VUInt16SIVUVUSI, f_vc_v_ivv_vi, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 4, ScalarIntXLen, OneDUInt16, OneDUInt16, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivvVI16VUInt16SIVUVUSI, f_vc_v_ivv_vi, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 4, ScalarIntXLen, OneDUInt16, OneDUInt16, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivvVI32VUInt32SIVUVUSI, f_vc_v_ivv_vi, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 4, ScalarIntXLen, OneDUInt32, OneDUInt32, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivvVI32VUInt32SIVUVUSI, f_vc_v_ivv_vi, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 4, ScalarIntXLen, OneDUInt32, OneDUInt32, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivvVI64VUInt64SIVUVUSI, f_vc_v_ivv_vi, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 4, ScalarIntXLen, OneDUInt64, OneDUInt64, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivvVI64VUInt64SIVUVUSI, f_vc_v_ivv_vi, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 4, ScalarIntXLen, OneDUInt64, OneDUInt64, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_fvvVF16VoidSIVUVUSF, f_vc_fvv_vf, 16, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt16, OneDUInt16, ScalarFloat16)
-CUSTOM_OP_TYPE(F_vc_fvvVF32VoidSIVUVUSF, f_vc_fvv_vf, 32, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt32, OneDUInt32, ScalarFloat32)
-CUSTOM_OP_TYPE(F_vc_fvvVF64VoidSIVUVUSF, f_vc_fvv_vf, 64, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt64, OneDUInt64, ScalarFloat64)
-CUSTOM_OP_TYPE(F_vc_v_fvvVF16VUInt16SIVUVUSF, f_vc_v_fvv_vf, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 4, ScalarIntXLen, OneDUInt16, OneDUInt16, ScalarFloat16)
-CUSTOM_OP_TYPE(F_vc_v_fvvVF16VUInt16SIVUVUSF, f_vc_v_fvv_vf, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 4, ScalarIntXLen, OneDUInt16, OneDUInt16, ScalarFloat16)
-CUSTOM_OP_TYPE(F_vc_v_fvvVF32VUInt32SIVUVUSF, f_vc_v_fvv_vf, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 4, ScalarIntXLen, OneDUInt32, OneDUInt32, ScalarFloat32)
-CUSTOM_OP_TYPE(F_vc_v_fvvVF32VUInt32SIVUVUSF, f_vc_v_fvv_vf, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 4, ScalarIntXLen, OneDUInt32, OneDUInt32, ScalarFloat32)
-CUSTOM_OP_TYPE(F_vc_v_fvvVF64VUInt64SIVUVUSF, f_vc_v_fvv_vf, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 4, ScalarIntXLen, OneDUInt64, OneDUInt64, ScalarFloat64)
-CUSTOM_OP_TYPE(F_vc_v_fvvVF64VUInt64SIVUVUSF, f_vc_v_fvv_vf, 64, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 4, ScalarIntXLen, OneDUInt64, OneDUInt64, ScalarFloat64)
-CUSTOM_OP_TYPE(F_vc_vvwVV8VoidSIVUVUVU, f_vc_vvw_vv, 8, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt16, OneDUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(F_vc_vvwVV16VoidSIVUVUVU, f_vc_vvw_vv, 16, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt32, OneDUInt16, OneDUInt16)
-CUSTOM_OP_TYPE(F_vc_vvwVV32VoidSIVUVUVU, f_vc_vvw_vv, 32, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt64, OneDUInt32, OneDUInt32)
-CUSTOM_OP_TYPE(F_vc_v_vvwVV8VUInt16SIVUVUVU, f_vc_v_vvw_vv, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 4, ScalarIntXLen, OneDUInt16, OneDUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(F_vc_v_vvwVV8VUInt16SIVUVUVU, f_vc_v_vvw_vv, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 4, ScalarIntXLen, OneDUInt16, OneDUInt8, OneDUInt8)
-CUSTOM_OP_TYPE(F_vc_v_vvwVV16VUInt32SIVUVUVU, f_vc_v_vvw_vv, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 4, ScalarIntXLen, OneDUInt32, OneDUInt16, OneDUInt16)
-CUSTOM_OP_TYPE(F_vc_v_vvwVV16VUInt32SIVUVUVU, f_vc_v_vvw_vv, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 4, ScalarIntXLen, OneDUInt32, OneDUInt16, OneDUInt16)
-CUSTOM_OP_TYPE(F_vc_v_vvwVV32VUInt64SIVUVUVU, f_vc_v_vvw_vv, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 4, ScalarIntXLen, OneDUInt64, OneDUInt32, OneDUInt32)
-CUSTOM_OP_TYPE(F_vc_v_vvwVV32VUInt64SIVUVUVU, f_vc_v_vvw_vv, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 4, ScalarIntXLen, OneDUInt64, OneDUInt32, OneDUInt32)
-CUSTOM_OP_TYPE(F_vc_xvwVX8VoidSIVUVUSU, f_vc_xvw_vx, 8, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt16, OneDUInt8, ScalarUInt8)
-CUSTOM_OP_TYPE(F_vc_xvwVX16VoidSIVUVUSU, f_vc_xvw_vx, 16, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt32, OneDUInt16, ScalarUInt16)
-CUSTOM_OP_TYPE(F_vc_xvwVX32VoidSIVUVUSU, f_vc_xvw_vx, 32, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt64, OneDUInt32, ScalarUInt32)
-CUSTOM_OP_TYPE(F_vc_v_xvwVX8VUInt16SIVUVUSU, f_vc_v_xvw_vx, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 4, ScalarIntXLen, OneDUInt16, OneDUInt8, ScalarUInt8)
-CUSTOM_OP_TYPE(F_vc_v_xvwVX8VUInt16SIVUVUSU, f_vc_v_xvw_vx, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 4, ScalarIntXLen, OneDUInt16, OneDUInt8, ScalarUInt8)
-CUSTOM_OP_TYPE(F_vc_v_xvwVX16VUInt32SIVUVUSU, f_vc_v_xvw_vx, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 4, ScalarIntXLen, OneDUInt32, OneDUInt16, ScalarUInt16)
-CUSTOM_OP_TYPE(F_vc_v_xvwVX16VUInt32SIVUVUSU, f_vc_v_xvw_vx, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 4, ScalarIntXLen, OneDUInt32, OneDUInt16, ScalarUInt16)
-CUSTOM_OP_TYPE(F_vc_v_xvwVX32VUInt64SIVUVUSU, f_vc_v_xvw_vx, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 4, ScalarIntXLen, OneDUInt64, OneDUInt32, ScalarUInt32)
-CUSTOM_OP_TYPE(F_vc_v_xvwVX32VUInt64SIVUVUSU, f_vc_v_xvw_vx, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 4, ScalarIntXLen, OneDUInt64, OneDUInt32, ScalarUInt32)
-CUSTOM_OP_TYPE(F_vc_ivwVI8VoidSIVUVUSI, f_vc_ivw_vi, 8, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt16, OneDUInt8, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_ivwVI16VoidSIVUVUSI, f_vc_ivw_vi, 16, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt32, OneDUInt16, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_ivwVI32VoidSIVUVUSI, f_vc_ivw_vi, 32, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt64, OneDUInt32, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivwVI8VUInt16SIVUVUSI, f_vc_v_ivw_vi, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 4, ScalarIntXLen, OneDUInt16, OneDUInt8, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivwVI8VUInt16SIVUVUSI, f_vc_v_ivw_vi, 8, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt16, 4, ScalarIntXLen, OneDUInt16, OneDUInt8, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivwVI16VUInt32SIVUVUSI, f_vc_v_ivw_vi, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 4, ScalarIntXLen, OneDUInt32, OneDUInt16, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivwVI16VUInt32SIVUVUSI, f_vc_v_ivw_vi, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 4, ScalarIntXLen, OneDUInt32, OneDUInt16, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivwVI32VUInt64SIVUVUSI, f_vc_v_ivw_vi, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 4, ScalarIntXLen, OneDUInt64, OneDUInt32, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_v_ivwVI32VUInt64SIVUVUSI, f_vc_v_ivw_vi, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 4, ScalarIntXLen, OneDUInt64, OneDUInt32, ScalarIntXLen)
-CUSTOM_OP_TYPE(F_vc_fvwVF16VoidSIVUVUSF, f_vc_fvw_vf, 16, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt32, OneDUInt16, ScalarFloat16)
-CUSTOM_OP_TYPE(F_vc_fvwVF32VoidSIVUVUSF, f_vc_fvw_vf, 32, VOID, HaveVLParameter | NonmaskedOperation | VoidOperation, Void, 4, ScalarIntXLen, OneDUInt64, OneDUInt32, ScalarFloat32)
-CUSTOM_OP_TYPE(F_vc_v_fvwVF16VUInt32SIVUVUSF, f_vc_v_fvw_vf, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 4, ScalarIntXLen, OneDUInt32, OneDUInt16, ScalarFloat16)
-CUSTOM_OP_TYPE(F_vc_v_fvwVF16VUInt32SIVUVUSF, f_vc_v_fvw_vf, 16, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt32, 4, ScalarIntXLen, OneDUInt32, OneDUInt16, ScalarFloat16)
-CUSTOM_OP_TYPE(F_vc_v_fvwVF32VUInt64SIVUVUSF, f_vc_v_fvw_vf, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 4, ScalarIntXLen, OneDUInt64, OneDUInt32, ScalarFloat32)
-CUSTOM_OP_TYPE(F_vc_v_fvwVF32VUInt64SIVUVUSF, f_vc_v_fvw_vf, 32, UNSIGNED_INT, HaveVLParameter | NonmaskedOperation, OneDUInt64, 4, ScalarIntXLen, OneDUInt64, OneDUInt32, ScalarFloat32)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/sifive_specific/vendor_generator.py
+++ b/sifive_specific/vendor_generator.py
@@ -197,7 +197,7 @@ class RIFGenerator(Generator):
     if inst_info.extra_attr & enums.ExtraAttr.INT_EXTENSION:
       op_id = f"{inst_info.OP[1:]}"
     elif inst_info.mem_type == enums.MemType.STORE:
-      op_id = f"{inst_info.OP}_v"
+      op_id = f"{inst_info.OP[1:]}_v"
     elif inst_info.OP.startswith("mv") or inst_info.OP.startswith("fmv"):
       op_id = f"{inst_info.OP[1:]}_{'_'.join(output_inst_type.lower())}"
     elif inst_info.OP == "id":
@@ -211,10 +211,10 @@ class RIFGenerator(Generator):
       op_id = f"{inst_info.OP[1:]}_{suffix}"
     else:
       op_id = f"{inst_info.OP[1:]}_{output_inst_type[1:].lower()}"
-    if is_load or is_store:
-      op_name = inst_info.OP
-    else:
-      op_name = inst_info.OP[1:]
+    # if is_load or is_store:
+    #   op_name = inst_info.OP
+    # else:
+    op_name = inst_info.OP[1:]
     op_type = f"{first_letter_upper(op_name)}\
 {output_inst_type[1:]}{inst_info.SEW}\
 {rif_return_type.short_type_name + in_args_sig_str}"


### PR DESCRIPTION
I don't know if there is any other place used the store type operator with op_name start with "v". But while using the auto-generated/rif.def to generate fuzzing test cases, the script generate head file name with "v + op_id + .h" format, then the store type would have 2 v and can't match the spike head file. By the way, the load type operator don't have the issue.

Try to fix it like this at first XD.